### PR TITLE
Add end adornment icon to refresh the room uuid()

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -73,12 +73,14 @@ export function Home({ userId }: HomeProps) {
                 InputProps={{
                   endAdornment: (
                     <IconButton
-                      aria-label="Regenerate room name"
+                      aria-label="Regenerate room id"
                       onClick={() => setRoomName(uuid())}
+                      size="small"
                     >
                       <Cached />
                     </IconButton>
                   ),
+                  sx: { fontSize: { xs: '0.9rem', sm: '1rem' } },
                 }}
                 size="medium"
               />

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -9,6 +9,7 @@ import Divider from '@mui/material/Divider'
 import IconButton from '@mui/material/IconButton'
 import MuiLink from '@mui/material/Link'
 import GitHubIcon from '@mui/icons-material/GitHub'
+import Cached from '@mui/icons-material/Cached'
 import Tooltip from '@mui/material/Tooltip'
 import { v4 as uuid } from 'uuid'
 
@@ -69,6 +70,16 @@ export function Home({ userId }: HomeProps) {
                 variant="outlined"
                 value={roomName}
                 onChange={handleRoomNameChange}
+                InputProps={{
+                  endAdornment: (
+                    <IconButton
+                      aria-label="Regenerate room name"
+                      onClick={() => setRoomName(uuid())}
+                    >
+                      <Cached />
+                    </IconButton>
+                  ),
+                }}
                 size="medium"
               />
             </Tooltip>


### PR DESCRIPTION
## Description
This change makes it so you can refresh the `uuid()` of the room before creating a room. Doesn't have much practical utility but since there's room in the textfield for it, why not? Users might want to shuffle their room IDs a few times before creating a room

This is also mobile compatible to 375px width (iPhone SE)
![image](https://user-images.githubusercontent.com/18077772/200106121-23502049-3365-443c-bbbb-7ad36965f542.png)
![image](https://user-images.githubusercontent.com/18077772/200106127-8608953c-c966-45a3-8973-647f1a7abd52.png)
