### PR TITLE
feat(connection-test): Display failed tracker connections

### DIFF
--- a/src/components/Shell/ConnectionTestResults.tsx
+++ b/src/components/Shell/ConnectionTestResults.tsx
@@ -3,6 +3,9 @@ import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import Circle from '@mui/icons-material/FiberManualRecord'
 import { Box } from '@mui/system'
+import ReportIcon from '@mui/icons-material/Report'
+
+import { TrackerConnection } from 'services/ConnectionTest/ConnectionTest'
 
 import { ConnectionTestResults as IConnectionTestResults } from './useConnectionTest'
 
@@ -10,9 +13,22 @@ interface ConnectionTestResultsProps {
   connectionTestResults: IConnectionTestResults
 }
 export const ConnectionTestResults = ({
-  connectionTestResults: { hasHost, hasRelay, hasTracker },
+  connectionTestResults: { hasHost, hasRelay, trackerConnection },
 }: ConnectionTestResultsProps) => {
-  if (!hasTracker) {
+  if (trackerConnection === TrackerConnection.FAILED) {
+    return (
+      <Typography variant="subtitle2">
+        <Box
+          sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}
+        >
+          <ReportIcon color="error" sx={{ mr: 1 }} />
+          <span>Server connection failed</span>
+        </Box>
+      </Typography>
+    )
+  }
+
+  if (trackerConnection !== TrackerConnection.CONNECTED) {
     return (
       <Typography variant="subtitle2">
         <Box

--- a/src/components/Shell/PeerList.tsx
+++ b/src/components/Shell/PeerList.tsx
@@ -16,6 +16,7 @@ import { PeerListHeader } from 'components/Shell/PeerListHeader'
 import { Username } from 'components/Username/Username'
 import { AudioState, Peer } from 'models/chat'
 import { PeerConnectionType } from 'services/PeerRoom/PeerRoom'
+import { TrackerConnection } from 'services/ConnectionTest/ConnectionTest'
 import { routes } from 'config/routes'
 
 import { PeerListItem } from './PeerListItem'
@@ -113,7 +114,8 @@ export const PeerList = ({
         ))}
         {peerList.length === 0 &&
         typeof roomId === 'string' &&
-        connectionTestResults.hasTracker &&
+        connectionTestResults.trackerConnection ===
+          TrackerConnection.CONNECTED &&
         connectionTestResults.hasHost ? (
           <>
             <Box

--- a/src/components/Shell/useConnectionTest.ts
+++ b/src/components/Shell/useConnectionTest.ts
@@ -4,12 +4,13 @@ import {
   ConnectionTest,
   ConnectionTestEvent,
   ConnectionTestEvents,
+  TrackerConnection,
 } from 'services/ConnectionTest/ConnectionTest'
 
 export interface ConnectionTestResults {
   hasHost: boolean
   hasRelay: boolean
-  hasTracker: boolean
+  trackerConnection: TrackerConnection
 }
 
 const rtcPollInterval = 20 * 1000
@@ -18,7 +19,9 @@ const trackerPollInterval = 5 * 1000
 export const useConnectionTest = () => {
   const [hasHost, setHasHost] = useState(false)
   const [hasRelay, setHasRelay] = useState(false)
-  const [hasTracker, setHasTracker] = useState(false)
+  const [trackerConnection, setTrackerConnection] = useState(
+    TrackerConnection.SEARCHING
+  )
 
   useEffect(() => {
     const checkRtcConnection = async () => {
@@ -83,14 +86,22 @@ export const useConnectionTest = () => {
     })()
     ;(async () => {
       while (true) {
-        const connectionTest = new ConnectionTest()
-        setHasTracker(connectionTest.testTrackerConnection())
+        try {
+          const connectionTest = new ConnectionTest()
+          const trackerConnectionTestResult =
+            connectionTest.testTrackerConnection()
+
+          setTrackerConnection(trackerConnectionTestResult)
+        } catch (e) {
+          setTrackerConnection(TrackerConnection.FAILED)
+        }
+
         await sleep(trackerPollInterval)
       }
     })()
   }, [])
 
   return {
-    connectionTestResults: { hasHost, hasRelay, hasTracker },
+    connectionTestResults: { hasHost, hasRelay, trackerConnection },
   }
 }

--- a/src/contexts/ShellContext.ts
+++ b/src/contexts/ShellContext.ts
@@ -4,6 +4,7 @@ import { AlertOptions } from 'models/shell'
 import { AudioState, ScreenShareState, VideoState, Peer } from 'models/chat'
 import { PeerConnectionType } from 'services/PeerRoom/PeerRoom'
 import { ConnectionTestResults } from 'components/Shell/useConnectionTest'
+import { TrackerConnection } from 'services/ConnectionTest/ConnectionTest'
 
 interface ShellContextProps {
   tabHasFocus: boolean
@@ -62,5 +63,9 @@ export const ShellContext = createContext<ShellContextProps>({
   setPeerAudios: () => {},
   customUsername: '',
   setCustomUsername: () => {},
-  connectionTestResults: { hasHost: false, hasRelay: false, hasTracker: false },
+  connectionTestResults: {
+    hasHost: false,
+    hasRelay: false,
+    trackerConnection: TrackerConnection.SEARCHING,
+  },
 })


### PR DESCRIPTION
This PR displays an error when no WebTorrent trackers can be reached.
![Screenshot from 2023-07-14 09-53-02](https://github.com/jeremyckahn/chitchatter/assets/366330/2ec0d671-b980-4a84-a9f0-1e51298f95c0)
