### PR TITLE
fix(file-upload): [#122] Prevent file picker from getting stuck

### DIFF
--- a/src/components/Room/RoomFileUploadControls.tsx
+++ b/src/components/Room/RoomFileUploadControls.tsx
@@ -51,7 +51,7 @@ export function RoomFileUploadControls({
   const handleFileSelect: ChangeEventHandler<HTMLInputElement> = e => {
     const { files } = e.target
 
-    if (!files) return
+    if (!files || files.length < 1) return
 
     handleFileShareStart(files)
   }


### PR DESCRIPTION
This PR fixes #122 by preventing the file upload button from getting stuck when the user cancels out of the file picker UI.