### PR TITLE
feat(media): [closes #157] Improve media button styling

### DIFF
--- a/src/components/Room/MediaButton.tsx
+++ b/src/components/Room/MediaButton.tsx
@@ -1,0 +1,49 @@
+import Fab, { FabProps } from '@mui/material/Fab'
+import { forwardRef } from 'react'
+
+interface MediaButtonProps extends Partial<FabProps> {
+  isActive: boolean
+}
+
+export const MediaButton = forwardRef<HTMLButtonElement, MediaButtonProps>(
+  ({ isActive, ...props }: MediaButtonProps, ref) => {
+    return (
+      <Fab
+        {...props}
+        ref={ref}
+        sx={theme =>
+          theme.palette.mode === 'dark'
+            ? isActive
+              ? {
+                  color: theme.palette.common.white,
+                  background: theme.palette.success.main,
+                  '&:hover': {
+                    background: theme.palette.success.dark,
+                  },
+                }
+              : {
+                  background: theme.palette.grey[500],
+                  '&:hover': {
+                    background: theme.palette.grey[600],
+                  },
+                }
+            : isActive
+            ? {
+                color: theme.palette.common.white,
+                background: theme.palette.success.main,
+                '&:hover': {
+                  background: theme.palette.success.dark,
+                },
+              }
+            : {
+                color: theme.palette.common.black,
+                background: theme.palette.grey[400],
+                '&:hover': {
+                  background: theme.palette.grey[500],
+                },
+              }
+        }
+      />
+    )
+  }
+)

--- a/src/components/Room/RoomAudioControls.tsx
+++ b/src/components/Room/RoomAudioControls.tsx
@@ -71,11 +71,11 @@ export function RoomAudioControls({ peerRoom }: RoomAudioControlsProps) {
         }
       >
         <Fab
-          color={isSpeakingToRoom ? 'error' : 'success'}
+          color={isSpeakingToRoom ? 'success' : 'default'}
           aria-label="call"
           onClick={handleVoiceCallClick}
         >
-          {isSpeakingToRoom ? <VoiceOverOff /> : <RecordVoiceOver />}
+          {isSpeakingToRoom ? <RecordVoiceOver /> : <VoiceOverOff />}
         </Fab>
       </Tooltip>
       {audioDevices.length > 0 && (

--- a/src/components/Room/RoomAudioControls.tsx
+++ b/src/components/Room/RoomAudioControls.tsx
@@ -7,12 +7,12 @@ import ListItem from '@mui/material/ListItem'
 import ListItemText from '@mui/material/ListItemText'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
-import Fab from '@mui/material/Fab'
 import Tooltip from '@mui/material/Tooltip'
 
 import { PeerRoom } from 'services/PeerRoom/PeerRoom'
 
 import { useRoomAudio } from './useRoomAudio'
+import { MediaButton } from './MediaButton'
 
 export interface RoomAudioControlsProps {
   peerRoom: PeerRoom
@@ -70,13 +70,13 @@ export function RoomAudioControls({ peerRoom }: RoomAudioControlsProps) {
             : 'Turn on microphone and speak to room'
         }
       >
-        <Fab
-          color={isSpeakingToRoom ? 'success' : 'default'}
+        <MediaButton
+          isActive={isSpeakingToRoom}
           aria-label="call"
           onClick={handleVoiceCallClick}
         >
           {isSpeakingToRoom ? <RecordVoiceOver /> : <VoiceOverOff />}
-        </Fab>
+        </MediaButton>
       </Tooltip>
       {audioDevices.length > 0 && (
         <Box sx={{ mt: 1 }}>

--- a/src/components/Room/RoomFileUploadControls.tsx
+++ b/src/components/Room/RoomFileUploadControls.tsx
@@ -1,7 +1,7 @@
 import { ChangeEventHandler, useContext, useRef } from 'react'
 import Box from '@mui/material/Box'
-import UploadFile from '@mui/icons-material/UploadFile'
-import Cancel from '@mui/icons-material/Cancel'
+import Folder from '@mui/icons-material/Folder'
+import FolderOff from '@mui/icons-material/FolderOff'
 import Fab from '@mui/material/Fab'
 import Tooltip from '@mui/material/Tooltip'
 import CircularProgress from '@mui/material/CircularProgress'
@@ -61,7 +61,7 @@ export function RoomFileUploadControls({
 
   const disableFileUpload = !isFileSharingEnabled || isMessageSending
 
-  const buttonIcon = isSharingFile ? <Cancel /> : <UploadFile />
+  const buttonIcon = isSharingFile ? <Folder /> : <FolderOff />
 
   return (
     <Box
@@ -89,7 +89,7 @@ export function RoomFileUploadControls({
         }
       >
         <Fab
-          color={isSharingFile ? 'error' : 'success'}
+          color={isSharingFile ? 'success' : 'default'}
           aria-label="share screen"
           onClick={handleToggleScreenShareButtonClick}
           disabled={disableFileUpload}

--- a/src/components/Room/RoomFileUploadControls.tsx
+++ b/src/components/Room/RoomFileUploadControls.tsx
@@ -2,7 +2,6 @@ import { ChangeEventHandler, useContext, useRef } from 'react'
 import Box from '@mui/material/Box'
 import Folder from '@mui/icons-material/Folder'
 import FolderOff from '@mui/icons-material/FolderOff'
-import Fab from '@mui/material/Fab'
 import Tooltip from '@mui/material/Tooltip'
 import CircularProgress from '@mui/material/CircularProgress'
 
@@ -10,6 +9,7 @@ import { RoomContext } from 'contexts/RoomContext'
 import { PeerRoom } from 'services/PeerRoom/PeerRoom'
 
 import { useRoomFileShare } from './useRoomFileShare'
+import { MediaButton } from './MediaButton'
 
 export interface RoomFileUploadControlsProps {
   onInlineMediaUpload: (files: File[]) => void
@@ -88,8 +88,8 @@ export function RoomFileUploadControls({
             : 'Share files with the room'
         }
       >
-        <Fab
-          color={isSharingFile ? 'success' : 'default'}
+        <MediaButton
+          isActive={isSharingFile}
           aria-label="share screen"
           onClick={handleToggleScreenShareButtonClick}
           disabled={disableFileUpload}
@@ -99,7 +99,7 @@ export function RoomFileUploadControls({
           ) : (
             <CircularProgress variant="indeterminate" color="inherit" />
           )}
-        </Fab>
+        </MediaButton>
       </Tooltip>
     </Box>
   )

--- a/src/components/Room/RoomScreenShareControls.tsx
+++ b/src/components/Room/RoomScreenShareControls.tsx
@@ -1,12 +1,12 @@
 import Box from '@mui/material/Box'
 import ScreenShare from '@mui/icons-material/ScreenShare'
 import StopScreenShare from '@mui/icons-material/StopScreenShare'
-import Fab from '@mui/material/Fab'
 import Tooltip from '@mui/material/Tooltip'
 
 import { PeerRoom } from 'services/PeerRoom/PeerRoom'
 
 import { useRoomScreenShare } from './useRoomScreenShare'
+import { MediaButton } from './MediaButton'
 
 export interface RoomFileUploadControlsProps {
   peerRoom: PeerRoom
@@ -47,13 +47,13 @@ export function RoomScreenShareControls({
           isSharingScreen ? 'Stop sharing screen' : 'Share screen with room'
         }
       >
-        <Fab
-          color={isSharingScreen ? 'success' : 'default'}
+        <MediaButton
+          isActive={isSharingScreen}
           aria-label="share screen"
           onClick={handleToggleScreenShareButtonClick}
         >
           {isSharingScreen ? <ScreenShare /> : <StopScreenShare />}
-        </Fab>
+        </MediaButton>
       </Tooltip>
     </Box>
   )

--- a/src/components/Room/RoomScreenShareControls.tsx
+++ b/src/components/Room/RoomScreenShareControls.tsx
@@ -48,11 +48,11 @@ export function RoomScreenShareControls({
         }
       >
         <Fab
-          color={isSharingScreen ? 'error' : 'success'}
+          color={isSharingScreen ? 'success' : 'default'}
           aria-label="share screen"
           onClick={handleToggleScreenShareButtonClick}
         >
-          {isSharingScreen ? <StopScreenShare /> : <ScreenShare />}
+          {isSharingScreen ? <ScreenShare /> : <StopScreenShare />}
         </Fab>
       </Tooltip>
     </Box>

--- a/src/components/Room/RoomShowMessagesControls.tsx
+++ b/src/components/Room/RoomShowMessagesControls.tsx
@@ -23,12 +23,12 @@ export function RoomShowMessagesControls() {
     >
       <Tooltip title={isShowingMessages ? 'Hide messages' : 'Show messages'}>
         <Fab
-          color={isShowingMessages ? 'error' : 'success'}
+          color={isShowingMessages ? 'success' : 'default'}
           aria-label="show messages"
           onClick={() => setIsShowingMessages(!isShowingMessages)}
         >
           <Badge color="error" badgeContent={unreadMessages}>
-            {isShowingMessages ? <CommentsDisabled /> : <Comment />}
+            {isShowingMessages ? <Comment /> : <CommentsDisabled />}
           </Badge>
         </Fab>
       </Tooltip>

--- a/src/components/Room/RoomShowMessagesControls.tsx
+++ b/src/components/Room/RoomShowMessagesControls.tsx
@@ -1,11 +1,12 @@
 import { useContext } from 'react'
 
-import Fab from '@mui/material/Fab'
 import Tooltip from '@mui/material/Tooltip'
 import { Comment, CommentsDisabled } from '@mui/icons-material'
 import { Badge, Box } from '@mui/material'
 
 import { RoomContext } from 'contexts/RoomContext'
+
+import { MediaButton } from './MediaButton'
 
 export function RoomShowMessagesControls() {
   const { isShowingMessages, setIsShowingMessages, unreadMessages } =
@@ -22,15 +23,15 @@ export function RoomShowMessagesControls() {
       }}
     >
       <Tooltip title={isShowingMessages ? 'Hide messages' : 'Show messages'}>
-        <Fab
-          color={isShowingMessages ? 'success' : 'default'}
+        <MediaButton
+          isActive={isShowingMessages}
           aria-label="show messages"
           onClick={() => setIsShowingMessages(!isShowingMessages)}
         >
           <Badge color="error" badgeContent={unreadMessages}>
             {isShowingMessages ? <Comment /> : <CommentsDisabled />}
           </Badge>
-        </Fab>
+        </MediaButton>
       </Tooltip>
     </Box>
   )

--- a/src/components/Room/RoomVideoControls.tsx
+++ b/src/components/Room/RoomVideoControls.tsx
@@ -65,11 +65,11 @@ export function RoomVideoControls({ peerRoom }: RoomVideoControlsProps) {
     >
       <Tooltip title={isCameraEnabled ? 'Turn off camera' : 'Turn on camera'}>
         <Fab
-          color={isCameraEnabled ? 'error' : 'success'}
+          color={isCameraEnabled ? 'success' : 'default'}
           aria-label="toggle camera"
           onClick={handleEnableCameraClick}
         >
-          {isCameraEnabled ? <VideocamOff /> : <Videocam />}
+          {isCameraEnabled ? <Videocam /> : <VideocamOff />}
         </Fab>
       </Tooltip>
       {videoDevices.length > 0 && (

--- a/src/components/Room/RoomVideoControls.tsx
+++ b/src/components/Room/RoomVideoControls.tsx
@@ -7,12 +7,12 @@ import ListItem from '@mui/material/ListItem'
 import ListItemText from '@mui/material/ListItemText'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
-import Fab from '@mui/material/Fab'
 import Tooltip from '@mui/material/Tooltip'
 
 import { PeerRoom } from 'services/PeerRoom/PeerRoom'
 
 import { useRoomVideo } from './useRoomVideo'
+import { MediaButton } from './MediaButton'
 
 export interface RoomVideoControlsProps {
   peerRoom: PeerRoom
@@ -64,13 +64,13 @@ export function RoomVideoControls({ peerRoom }: RoomVideoControlsProps) {
       }}
     >
       <Tooltip title={isCameraEnabled ? 'Turn off camera' : 'Turn on camera'}>
-        <Fab
-          color={isCameraEnabled ? 'success' : 'default'}
+        <MediaButton
+          isActive={isCameraEnabled}
           aria-label="toggle camera"
           onClick={handleEnableCameraClick}
         >
           {isCameraEnabled ? <Videocam /> : <VideocamOff />}
-        </Fab>
+        </MediaButton>
       </Tooltip>
       {videoDevices.length > 0 && (
         <Box sx={{ mt: 1 }}>


### PR DESCRIPTION
For #157, this PR improves the styling of the media controls to look more like what users expect from other chat apps.

New design:

![image](https://github.com/jeremyckahn/chitchatter/assets/366330/70e60d8e-00cc-40bf-acd0-e3f1c0ae39f5)

![image](https://github.com/jeremyckahn/chitchatter/assets/366330/2a827f15-4852-4451-b852-7164885d2935)

![image](https://github.com/jeremyckahn/chitchatter/assets/366330/b7a7a823-2b5c-4fe5-bf0b-2e2bd57d9a04)

![image](https://github.com/jeremyckahn/chitchatter/assets/366330/8389a14d-62ad-4d4c-aa35-80b08e44bc24)

![image](https://github.com/jeremyckahn/chitchatter/assets/366330/7bfd210d-ca16-4bd3-abe0-9d09451a1bb7)

![image](https://github.com/jeremyckahn/chitchatter/assets/366330/1e13aa35-9071-454e-95db-dd21196f37c5)

<details>

<summary>Old design</summary>

![image](https://github.com/jeremyckahn/chitchatter/assets/366330/5b589c35-2263-4245-ae67-8a086a8c7a01)

![image](https://github.com/jeremyckahn/chitchatter/assets/366330/0f78bd87-f28a-4100-a2ee-df7a1a3ea4b6)

![image](https://github.com/jeremyckahn/chitchatter/assets/366330/7703219e-5f49-4db6-b66d-95d0e6cb3cb7)

![image](https://github.com/jeremyckahn/chitchatter/assets/366330/5ba5753a-ced7-4681-9206-a5c7afabae77)

![image](https://github.com/jeremyckahn/chitchatter/assets/366330/3440474e-3b05-44e8-9eb6-7137fb591ff9)

![image](https://github.com/jeremyckahn/chitchatter/assets/366330/ab50389f-c0cb-49dd-b31b-6c8238ae9e8b)


</details>