### PR TITLE
feat(media): [closes #165] Hide media control selectors when not in use

### DIFF
--- a/src/components/Room/RoomAudioControls.tsx
+++ b/src/components/Room/RoomAudioControls.tsx
@@ -78,7 +78,7 @@ export function RoomAudioControls({ peerRoom }: RoomAudioControlsProps) {
           {isSpeakingToRoom ? <RecordVoiceOver /> : <VoiceOverOff />}
         </MediaButton>
       </Tooltip>
-      {audioDevices.length > 0 && (
+      {audioDevices.length > 0 && isSpeakingToRoom && (
         <Box sx={{ mt: 1 }}>
           <List
             component="nav"

--- a/src/components/Room/RoomVideoControls.tsx
+++ b/src/components/Room/RoomVideoControls.tsx
@@ -72,7 +72,7 @@ export function RoomVideoControls({ peerRoom }: RoomVideoControlsProps) {
           {isCameraEnabled ? <Videocam /> : <VideocamOff />}
         </MediaButton>
       </Tooltip>
-      {videoDevices.length > 0 && (
+      {videoDevices.length > 0 && isCameraEnabled && (
         <Box sx={{ mt: 1 }}>
           <List
             component="nav"


### PR DESCRIPTION
it fix #165 
<img width="368" alt="Screenshot 2023-09-16 at 5 44 08 PM" src="https://github.com/jeremyckahn/chitchatter/assets/114856815/288368c4-b943-406e-ac33-b01f902a5b7d">
