### PR TITLE
fix(routing): [closes #168] Support GitHub Pages routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
     "webrtc-adapter": "^8.2.2"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "cross-env REACT_APP_HOMEPAGE=$(npm pkg get homepage) react-scripts start",
     "start:tracker": "bittorrent-tracker",
     "start:streamsaver": "serve -p 3015 node_modules/streamsaver",
     "dev": "mprocs \"npx cross-env REACT_APP_TRACKER_URL=\"ws://localhost:8000\" REACT_APP_STREAMSAVER_URL=\"http://localhost:3015/mitm.html\" npm run start\" \"npm run start:tracker\" \"npm run start:streamsaver\"",
-    "build": "react-scripts build",
+    "build": "cross-env REACT_APP_HOMEPAGE=$(npm pkg get homepage) react-scripts build",
     "test": "react-scripts test",
     "prepare": "husky install",
     "prettier": "prettier 'src/**/*.js' --write",

--- a/src/Bootstrap.tsx
+++ b/src/Bootstrap.tsx
@@ -27,6 +27,10 @@ export interface BootstrapProps {
   getUuid?: typeof uuid
 }
 
+const homepageUrl = new URL(
+  process.env.REACT_APP_HOMEPAGE ?? 'https://chitchatter.im/'
+)
+
 function Bootstrap({
   persistedStorage: persistedStorageProp = localforage.createInstance({
     name: 'chitchatter',
@@ -99,7 +103,7 @@ function Bootstrap({
   }
 
   return (
-    <Router>
+    <Router basename={homepageUrl.pathname}>
       <StorageContext.Provider value={storageContextValue}>
         <SettingsContext.Provider value={settingsContextValue}>
           {hasLoadedSettings ? (


### PR DESCRIPTION
For #168, this PR sets the appropriate router `basename` so that clent-side routes work as expected.