### PR TITLE
feat(ui): Add copy button for code

### DIFF
--- a/src/components/CopyableBlock/CopyableBlock.tsx
+++ b/src/components/CopyableBlock/CopyableBlock.tsx
@@ -1,4 +1,5 @@
 import Box, { BoxProps } from '@mui/material/Box'
+import Tooltip from '@mui/material/Tooltip'
 import Fab from '@mui/material/Fab'
 import ContentCopy from '@mui/icons-material/ContentCopy'
 import { useContext, useRef } from 'react'
@@ -31,20 +32,22 @@ export const CopyableBlock = ({ children }: CopyableBlockProps) => {
       }}
     >
       {children}
-      <Fab
-        color="default"
-        size="small"
-        onClick={handleCopyClick}
-        sx={theme => ({
-          position: 'absolute',
-          top: '1em',
-          right: '1em',
-          opacity: 0,
-          transition: theme.transitions.create(['opacity', 'transform']),
-        })}
-      >
-        <ContentCopy />
-      </Fab>
+      <Tooltip title="Copy to clipboard">
+        <Fab
+          color="default"
+          size="small"
+          onClick={handleCopyClick}
+          sx={theme => ({
+            position: 'absolute',
+            top: '1em',
+            right: '1em',
+            opacity: 0,
+            transition: theme.transitions.create(['opacity', 'transform']),
+          })}
+        >
+          <ContentCopy />
+        </Fab>
+      </Tooltip>
     </Box>
   )
 }

--- a/src/components/CopyableBlock/CopyableBlock.tsx
+++ b/src/components/CopyableBlock/CopyableBlock.tsx
@@ -27,7 +27,7 @@ export const CopyableBlock = ({ children }: CopyableBlockProps) => {
       sx={{
         position: 'relative',
         '&:hover button': {
-          opacity: 1,
+          opacity: 0.75,
         },
       }}
     >

--- a/src/components/CopyableBlock/CopyableBlock.tsx
+++ b/src/components/CopyableBlock/CopyableBlock.tsx
@@ -1,0 +1,36 @@
+import Box, { BoxProps } from '@mui/material/Box'
+import Fab from '@mui/material/Fab'
+import ContentCopy from '@mui/icons-material/ContentCopy'
+
+interface CopyableBlockProps extends BoxProps {}
+
+export const CopyableBlock = ({ children }: CopyableBlockProps) => {
+  const handleCopyClick = () => {}
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        '&:hover button': {
+          opacity: 1,
+        },
+      }}
+    >
+      {children}
+      <Fab
+        color="default"
+        size="small"
+        onClick={handleCopyClick}
+        sx={theme => ({
+          position: 'absolute',
+          top: '1em',
+          right: '1em',
+          opacity: 0,
+          transition: theme.transitions.create(['opacity', 'transform']),
+        })}
+      >
+        <ContentCopy />
+      </Fab>
+    </Box>
+  )
+}

--- a/src/components/CopyableBlock/CopyableBlock.tsx
+++ b/src/components/CopyableBlock/CopyableBlock.tsx
@@ -18,7 +18,7 @@ export const CopyableBlock = ({ children }: CopyableBlockProps) => {
 
     await navigator.clipboard.writeText(div.innerText)
 
-    showAlert('Text copied to clipboard', { severity: 'success' })
+    showAlert('Copied to clipboard', { severity: 'success' })
   }
 
   return (

--- a/src/components/CopyableBlock/CopyableBlock.tsx
+++ b/src/components/CopyableBlock/CopyableBlock.tsx
@@ -1,14 +1,28 @@
 import Box, { BoxProps } from '@mui/material/Box'
 import Fab from '@mui/material/Fab'
 import ContentCopy from '@mui/icons-material/ContentCopy'
+import { useContext, useRef } from 'react'
+import { ShellContext } from 'contexts/ShellContext'
 
 interface CopyableBlockProps extends BoxProps {}
 
 export const CopyableBlock = ({ children }: CopyableBlockProps) => {
-  const handleCopyClick = () => {}
+  const { showAlert } = useContext(ShellContext)
+  const boxRef = useRef<HTMLDivElement>(null)
+
+  const handleCopyClick = async () => {
+    const div = boxRef?.current
+
+    if (!div) return
+
+    await navigator.clipboard.writeText(div.innerText)
+
+    showAlert('Text copied to clipboard', { severity: 'success' })
+  }
 
   return (
     <Box
+      ref={boxRef}
       sx={{
         position: 'relative',
         '&:hover button': {

--- a/src/components/CopyableBlock/index.ts
+++ b/src/components/CopyableBlock/index.ts
@@ -1,0 +1,1 @@
+export * from './CopyableBlock'

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -1,4 +1,5 @@
 import { HTMLAttributes } from 'react'
+import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter'
 import YouTube from 'react-youtube'
 import Box from '@mui/material/Box'
 import Tooltip from '@mui/material/Tooltip'
@@ -28,8 +29,6 @@ import {
 } from 'models/chat'
 import { PeerNameDisplay } from 'components/PeerNameDisplay'
 import { CopyableBlock } from 'components/CopyableBlock/CopyableBlock'
-
-import { SyntaxHighlighter } from '../../components/SyntaxHighlighter'
 
 import { InlineMedia } from './InlineMedia'
 

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -27,10 +27,12 @@ import {
   isInlineMedia,
 } from 'models/chat'
 import { PeerNameDisplay } from 'components/PeerNameDisplay'
+import { CopyableBlock } from 'components/CopyableBlock/CopyableBlock'
 
 import { SyntaxHighlighter } from '../../components/SyntaxHighlighter'
 
 import { InlineMedia } from './InlineMedia'
+
 import './Message.sass'
 
 export interface MessageProps {
@@ -65,14 +67,17 @@ const componentMap = {
   // https://github.com/remarkjs/react-markdown#use-custom-components-syntax-highlight
   code({ node, inline, className, children, style, ...props }: CodeProps) {
     const match = /language-(\w+)/.exec(className || '')
+
     return !inline && match ? (
-      <SyntaxHighlighter
-        children={String(children).replace(/\n$/, '')}
-        language={match[1]}
-        style={materialDark}
-        PreTag="div"
-        {...props}
-      />
+      <CopyableBlock>
+        <SyntaxHighlighter
+          children={String(children).replace(/\n$/, '')}
+          language={match[1]}
+          style={materialDark}
+          PreTag="div"
+          {...props}
+        />
+      </CopyableBlock>
     ) : (
       <code className={className} {...props}>
         {children}

--- a/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -1,3 +1,0 @@
-import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter'
-
-export { SyntaxHighlighter }

--- a/src/components/SyntaxHighlighter/index.ts
+++ b/src/components/SyntaxHighlighter/index.ts
@@ -1,1 +1,0 @@
-export * from './SyntaxHighlighter'

--- a/src/pages/Home/EmbedCodeDialog.tsx
+++ b/src/pages/Home/EmbedCodeDialog.tsx
@@ -1,3 +1,4 @@
+import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter'
 import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
 import { materialDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
@@ -6,8 +7,6 @@ import DialogContent from '@mui/material/DialogContent'
 import DialogContentText from '@mui/material/DialogContentText'
 import DialogTitle from '@mui/material/DialogTitle'
 import { CopyableBlock } from 'components/CopyableBlock/CopyableBlock'
-
-import { SyntaxHighlighter } from '../../components/SyntaxHighlighter'
 
 interface EmbedCodeDialogProps {
   showEmbedCode: boolean

--- a/src/pages/Home/EmbedCodeDialog.tsx
+++ b/src/pages/Home/EmbedCodeDialog.tsx
@@ -5,6 +5,7 @@ import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogContentText from '@mui/material/DialogContentText'
 import DialogTitle from '@mui/material/DialogTitle'
+import { CopyableBlock } from 'components/CopyableBlock/CopyableBlock'
 
 import { SyntaxHighlighter } from '../../components/SyntaxHighlighter'
 
@@ -29,22 +30,24 @@ export const EmbedCodeDialog = ({
   <Dialog open={showEmbedCode} onClose={handleEmbedCodeWindowClose}>
     <DialogTitle>Room embed code</DialogTitle>
     <DialogContent>
-      <SyntaxHighlighter
-        language="html"
-        style={materialDark}
-        PreTag="div"
-        lineProps={{
-          style: {
-            wordBreak: 'break-all',
-            whiteSpace: 'pre-wrap',
-          },
-        }}
-        wrapLines={true}
-      >
-        {`<iframe src="${embedUrl}" allow="${iframeFeatureAllowList.join(
-          ';'
-        )}" width="800" height="800" />`}
-      </SyntaxHighlighter>
+      <CopyableBlock>
+        <SyntaxHighlighter
+          language="html"
+          style={materialDark}
+          PreTag="div"
+          lineProps={{
+            style: {
+              wordBreak: 'break-all',
+              whiteSpace: 'pre-wrap',
+            },
+          }}
+          wrapLines={true}
+        >
+          {`<iframe src="${embedUrl}" allow="${iframeFeatureAllowList.join(
+            ';'
+          )}" width="800" height="800" />`}
+        </SyntaxHighlighter>
+      </CopyableBlock>
       <DialogContentText
         sx={{
           mb: 2,


### PR DESCRIPTION
This PR implements a "copy to clipboard" button for code blocks.

[Text copying screencast](https://github.com/jeremyckahn/chitchatter/assets/366330/ed460b7c-5f82-4254-89d5-a708b95d871d)
