### PR TITLE
fix(ci): Use GitHub output for `security.yml`

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,9 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Scan Production Site
     steps:
-      - name: Set Date (NOW) as Env Var
+      - name: Set Date (NOW) as Variable
+        id: set-now
         run: |
-          echo "::set-env name=NOW::$(date +'%Y-%m-%d')"
+          echo "NOW=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Main Branch for .zap/rules.tsv
         uses: actions/checkout@v4
@@ -30,5 +31,5 @@ jobs:
         with:
           target: 'https://chitchatter.im/'
           rules_file_name: '.zap/rules.tsv'
-          issue_title: 'Security Report - ${{ env.NOW }}'
-          artifact_name: 'zap_scan_${{ env.NOW }}'
+          issue_title: 'Security Report - ${{ steps.set-now.outputs.NOW }}'
+          artifact_name: 'zap_scan_${{ steps.set-now.outputs.NOW }}'


### PR DESCRIPTION
This PR fixes [an issue](https://github.com/jeremyckahn/chitchatter/pull/196#issuecomment-1787079369) that resulted from #196.