### PR TITLE
feat(audio) [closes #180] Mute own screen stream

### DIFF
--- a/src/components/Room/PeerVideo.tsx
+++ b/src/components/Room/PeerVideo.tsx
@@ -8,6 +8,7 @@ import { VideoStreamType } from 'models/chat'
 import { SelectedPeerStream } from './RoomVideoDisplay'
 
 interface PeerVideoProps {
+  isSelfScreenStream?: boolean
   isSelfVideo?: boolean
   numberOfVideos: number
   onVideoClick?: (
@@ -29,6 +30,7 @@ const nextPerfectSquare = (base: number) => {
 }
 
 export const PeerVideo = ({
+  isSelfScreenStream,
   isSelfVideo,
   numberOfVideos,
   onVideoClick,
@@ -87,6 +89,7 @@ export const PeerVideo = ({
       >
         <video
           playsInline
+          muted={isSelfScreenStream}
           ref={videoRef}
           onClick={handleVideoClick}
           style={{

--- a/src/components/Room/RoomVideoDisplay.tsx
+++ b/src/components/Room/RoomVideoDisplay.tsx
@@ -173,6 +173,7 @@ export const RoomVideoDisplay = ({
         )}
         {selfScreenStream && (
           <PeerVideo
+            isSelfScreenStream
             numberOfVideos={numberOfVideos}
             onVideoClick={handleVideoClick}
             userId={userId}

--- a/src/components/Room/useRoomVideo.ts
+++ b/src/components/Room/useRoomVideo.ts
@@ -66,8 +66,6 @@ export function useRoomVideo({ peerRoom }: UseRoomVideoConfig) {
           type: VideoStreamType.WEBCAM,
         })
         setSelfVideoStream(newSelfStream)
-
-        setSelfVideoStream(newSelfStream)
       }
     })()
   }, [peerRoom, selfVideoStream, setSelfVideoStream])
@@ -143,7 +141,6 @@ export function useRoomVideo({ peerRoom }: UseRoomVideoConfig) {
           peerRoom.removeStream(selfVideoStream, peerRoom.getPeers())
           sendVideoChange(VideoState.STOPPED)
           setVideoState(VideoState.STOPPED)
-          setSelfVideoStream(null)
           setSelfVideoStream(null)
         }
       }


### PR DESCRIPTION
For #180, this PR mutes the audio of the `<video />` presenting the user's own screen stream.