### PR TITLE
feat(ui) [closes #160] Move transcript scrollbar to content window edge

### DIFF
--- a/src/components/ChatTranscript/ChatTranscript.tsx
+++ b/src/components/ChatTranscript/ChatTranscript.tsx
@@ -1,10 +1,11 @@
-import { HTMLAttributes, useRef, useEffect, useState } from 'react'
+import { HTMLAttributes, useRef, useEffect, useState, useContext } from 'react'
 import cx from 'classnames'
 import Box from '@mui/material/Box'
+import useTheme from '@mui/material/styles/useTheme'
 
 import { Message as IMessage, InlineMedia } from 'models/chat'
 import { Message } from 'components/Message'
-import useTheme from '@mui/material/styles/useTheme'
+import { ShellContext } from 'contexts/ShellContext'
 
 export interface ChatTranscriptProps extends HTMLAttributes<HTMLDivElement> {
   messageLog: Array<IMessage | InlineMedia>
@@ -16,6 +17,7 @@ export const ChatTranscript = ({
   messageLog,
   userId,
 }: ChatTranscriptProps) => {
+  const { showRoomControls } = useContext(ShellContext)
   const theme = useTheme()
   const boxRef = useRef<HTMLDivElement>(null)
   const [previousMessageLogLength, setPreviousMessageLogLength] = useState(0)
@@ -69,7 +71,9 @@ export const ChatTranscript = ({
         display: 'flex',
         flexDirection: 'column',
         py: transcriptMinPadding,
+        pt: showRoomControls ? theme.spacing(10) : theme.spacing(2),
         px: `max(${transcriptPaddingX}, ${transcriptMinPadding})`,
+        transition: `padding-top ${theme.transitions.duration.short}ms ${theme.transitions.easing.easeInOut}`,
         width: '100%',
       }}
     >

--- a/src/components/ChatTranscript/ChatTranscript.tsx
+++ b/src/components/ChatTranscript/ChatTranscript.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box'
 
 import { Message as IMessage, InlineMedia } from 'models/chat'
 import { Message } from 'components/Message'
+import useTheme from '@mui/material/styles/useTheme'
 
 export interface ChatTranscriptProps extends HTMLAttributes<HTMLDivElement> {
   messageLog: Array<IMessage | InlineMedia>
@@ -15,6 +16,7 @@ export const ChatTranscript = ({
   messageLog,
   userId,
 }: ChatTranscriptProps) => {
+  const theme = useTheme()
   const boxRef = useRef<HTMLDivElement>(null)
   const [previousMessageLogLength, setPreviousMessageLogLength] = useState(0)
 
@@ -53,18 +55,23 @@ export const ChatTranscript = ({
     setPreviousMessageLogLength(messageLog.length)
   }, [messageLog.length])
 
+  const transcriptMaxWidth = theme.breakpoints.values.md
+  const transcriptPaddingX = `(50% - ${
+    transcriptMaxWidth / 2
+  }px) - ${theme.spacing(1)}`
+  const transcriptMinPadding = theme.spacing(1)
+
   return (
     <Box
       ref={boxRef}
       className={cx('ChatTranscript', className)}
-      sx={theme => ({
+      sx={{
         display: 'flex',
         flexDirection: 'column',
-        mx: 'auto',
-        paddingY: theme.spacing(1),
+        py: transcriptMinPadding,
+        px: `max(${transcriptPaddingX}, ${transcriptMinPadding})`,
         width: '100%',
-        maxWidth: theme.breakpoints.values.md,
-      })}
+      }}
     >
       {messageLog.map((message, idx) => {
         const previousMessage = messageLog[idx - 1]

--- a/src/components/Room/Room.tsx
+++ b/src/components/Room/Room.tsx
@@ -1,9 +1,9 @@
 import { useContext } from 'react'
 import { useWindowSize } from '@react-hook/window-size'
-import Collapse from '@mui/material/Collapse'
 import Zoom from '@mui/material/Zoom'
 import Box from '@mui/material/Box'
 import Divider from '@mui/material/Divider'
+import useTheme from '@mui/material/styles/useTheme'
 import { v4 as uuid } from 'uuid'
 
 import { rtcConfig } from 'config/rtcConfig'
@@ -40,6 +40,7 @@ export function Room({
   password,
   userId,
 }: RoomProps) {
+  const theme = useTheme()
   const settingsContext = useContext(SettingsContext)
   const { showActiveTypingStatus } = settingsContext.getUserSettings()
   const {
@@ -96,14 +97,16 @@ export function Room({
             overflow: 'auto',
           }}
         >
-          <Collapse in={showRoomControls}>
+          <Zoom in={showRoomControls}>
             <Box
               sx={{
                 alignItems: 'flex-start',
                 display: 'flex',
                 justifyContent: 'center',
-                padding: 1,
-                overflowX: 'auto',
+                overflow: 'visible',
+                height: 0,
+                position: 'relative',
+                top: theme.spacing(1),
               }}
             >
               <RoomAudioControls peerRoom={peerRoom} />
@@ -120,7 +123,7 @@ export function Room({
               </Zoom>
               <RoomHideRoomControls />
             </Box>
-          </Collapse>
+          </Zoom>
           <Box
             sx={{
               display: 'flex',
@@ -150,7 +153,7 @@ export function Room({
                 <ChatTranscript
                   messageLog={messageLog}
                   userId={userId}
-                  className="grow overflow-auto px-4"
+                  className="grow overflow-auto"
                 />
                 <Divider />
                 <Box>

--- a/src/components/Room/Room.tsx
+++ b/src/components/Room/Room.tsx
@@ -22,7 +22,6 @@ import { RoomScreenShareControls } from './RoomScreenShareControls'
 import { RoomFileUploadControls } from './RoomFileUploadControls'
 import { RoomVideoDisplay } from './RoomVideoDisplay'
 import { RoomShowMessagesControls } from './RoomShowMessagesControls'
-import { RoomHideRoomControls } from './RoomHideRoomControls'
 import { TypingStatusBar } from './TypingStatusBar'
 
 export interface RoomProps {
@@ -121,7 +120,6 @@ export function Room({
                   <RoomShowMessagesControls />
                 </span>
               </Zoom>
-              <RoomHideRoomControls />
             </Box>
           </Zoom>
           <Box

--- a/src/components/Shell/ShellAppBar.tsx
+++ b/src/components/Shell/ShellAppBar.tsx
@@ -85,7 +85,7 @@ export const ShellAppBar = ({
   isFullscreen,
   setIsFullscreen,
 }: ShellAppBarProps) => {
-  const { peerList, isEmbedded } = useContext(ShellContext)
+  const { peerList, isEmbedded, showRoomControls } = useContext(ShellContext)
   const handleQRCodeClick = () => setIsQRCodeDialogOpen(true)
   const onClickFullscreen = () => setIsFullscreen(!isFullscreen)
 
@@ -149,7 +149,11 @@ export const ShellAppBar = ({
                 </Tooltip>
               </>
             )}
-            <Tooltip title="Show Room Controls">
+            <Tooltip
+              title={
+                showRoomControls ? 'Hide Room Controls' : 'Show Room Controls'
+              }
+            >
               <IconButton
                 size="large"
                 color="inherit"


### PR DESCRIPTION
This PR makes some UI improvements:

- It addresses #160 by moving the transcript scrollbar to the edge of the content area
- It improves the display of the room controls
- It removes a redundant button for hiding room controls

[Screencast from 11-23-2023 12:14:43 PM.webm](https://github.com/jeremyckahn/chitchatter/assets/366330/7f0399fe-18f3-42c5-bce1-83f93e298fd9)
