### PR TITLE
feat(ui) App bar improvements

### DIFF
--- a/src/components/Shell/ShellAppBar.tsx
+++ b/src/components/Shell/ShellAppBar.tsx
@@ -1,4 +1,4 @@
-import { styled } from '@mui/material/styles'
+import { styled, useTheme } from '@mui/material/styles'
 
 import IconButton from '@mui/material/IconButton'
 import MuiAppBar, { AppBarProps as MuiAppBarProps } from '@mui/material/AppBar'
@@ -9,6 +9,7 @@ import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import Slide from '@mui/material/Slide'
 import Zoom from '@mui/material/Zoom'
+import Divider from '@mui/material/Divider'
 
 import ExpandMore from '@mui/icons-material/ExpandMore'
 import Fullscreen from '@mui/icons-material/Fullscreen'
@@ -85,6 +86,7 @@ export const ShellAppBar = ({
   isFullscreen,
   setIsFullscreen,
 }: ShellAppBarProps) => {
+  const theme = useTheme()
   const { peerList, isEmbedded, showRoomControls } = useContext(ShellContext)
   const handleQRCodeClick = () => setIsQRCodeDialogOpen(true)
   const onClickFullscreen = () => setIsFullscreen(!isFullscreen)
@@ -148,6 +150,12 @@ export const ShellAppBar = ({
                   </IconButton>
                 </Tooltip>
               </>
+            )}
+            {isEmbedded ? null : (
+              <Divider
+                orientation="vertical"
+                sx={{ height: theme.spacing(3.5), mx: theme.spacing(1) }}
+              />
             )}
             <Tooltip
               title={

--- a/src/components/Shell/ShellAppBar.tsx
+++ b/src/components/Shell/ShellAppBar.tsx
@@ -104,7 +104,7 @@ export const ShellAppBar = ({
             sx={{
               display: 'flex',
               flexDirection: 'row',
-              justifyContent: 'space-between',
+              justifyContent: 'right',
             }}
           >
             {isEmbedded ? null : (
@@ -119,14 +119,21 @@ export const ShellAppBar = ({
                 <Menu />
               </IconButton>
             )}
-            <Typography
-              variant="h6"
-              noWrap
-              component="div"
-              sx={{ marginRight: 'auto' }}
-            >
-              {isEmbedded ? '' : title}
-            </Typography>
+
+            {isEmbedded ? null : (
+              <Tooltip title={title}>
+                <Typography
+                  variant="h6"
+                  noWrap
+                  component="div"
+                  sx={{
+                    marginRight: 'auto',
+                  }}
+                >
+                  {title}
+                </Typography>
+              </Tooltip>
+            )}
             {isEmbedded ? null : (
               <>
                 <Tooltip title="Copy current URL">


### PR DESCRIPTION
This PR improves the display of the app bar:

- A divider is added between the QR code and control toggle buttons
- Hovering the room name shows the full room name

![Screenshot of UI improvements](https://github.com/jeremyckahn/chitchatter/assets/366330/1c445e9b-1428-4987-8e24-ea11cc1b38ca)
