### PR TITLE
fix(ui): [fixes #217] Give volume slider full width of peer list

### DIFF
--- a/src/components/Shell/PeerListItem.tsx
+++ b/src/components/Shell/PeerListItem.tsx
@@ -61,7 +61,7 @@ export const PeerListItem = ({
   const isPeerConnectionDirect =
     peerConnectionTypes[peer.peerId] === PeerConnectionType.DIRECT
 
-  const handleListItemClick = () => {
+  const handleListItemTextClick = () => {
     setShowPeerDialog(true)
   }
 
@@ -76,7 +76,7 @@ export const PeerListItem = ({
         <ListItemText>
           <Box
             sx={{ display: 'flex', alignContent: 'center', cursor: 'pointer' }}
-            onClick={handleListItemClick}
+            onClick={handleListItemTextClick}
           >
             {hasPeerConnection ? (
               <Tooltip

--- a/src/components/Shell/PeerListItem.tsx
+++ b/src/components/Shell/PeerListItem.tsx
@@ -71,63 +71,59 @@ export const PeerListItem = ({
 
   return (
     <>
-      <ListItem
-        key={peer.peerId}
-        divider={true}
-        onClick={handleListItemClick}
-        sx={{ cursor: 'pointer' }}
-      >
+      <ListItem key={peer.peerId} divider={true}>
         <PeerDownloadFileButton peer={peer} />
-        <ListItemText
-          primaryTypographyProps={{
-            sx: { display: 'flex', alignContent: 'center' },
-          }}
-        >
-          {hasPeerConnection ? (
-            <Tooltip
-              title={
-                isPeerConnectionDirect ? (
-                  <>
-                    You are connected directly to{' '}
-                    <PeerNameDisplay
-                      sx={{ fontSize: 'inherit', fontWeight: 'inherit' }}
-                    >
-                      {peer.userId}
-                    </PeerNameDisplay>
-                  </>
-                ) : (
-                  <>
-                    You are connected to{' '}
-                    <PeerNameDisplay
-                      sx={{ fontSize: 'inherit', fontWeight: 'inherit' }}
-                    >
-                      {peer.userId}
-                    </PeerNameDisplay>{' '}
-                    via a relay server. Your connection is still private and
-                    encrypted, but performance may be degraded.
-                  </>
-                )
-              }
-            >
-              <Box
-                component="span"
-                sx={{ pr: iconRightPadding, cursor: 'pointer' }}
-              >
-                {isPeerConnectionDirect ? (
-                  <SyncAltIcon color="success" />
-                ) : (
-                  <NetworkPingIcon color="warning" />
-                )}
-              </Box>
-            </Tooltip>
-          ) : null}
+        <ListItemText>
           <Box
-            component="span"
-            sx={{ pr: iconRightPadding, cursor: 'pointer' }}
+            sx={{ display: 'flex', alignContent: 'center', cursor: 'pointer' }}
+            onClick={handleListItemClick}
           >
-            {verificationStateDisplayMap[peer.verificationState]}
+            {hasPeerConnection ? (
+              <Tooltip
+                title={
+                  isPeerConnectionDirect ? (
+                    <>
+                      You are connected directly to{' '}
+                      <PeerNameDisplay
+                        sx={{ fontSize: 'inherit', fontWeight: 'inherit' }}
+                      >
+                        {peer.userId}
+                      </PeerNameDisplay>
+                    </>
+                  ) : (
+                    <>
+                      You are connected to{' '}
+                      <PeerNameDisplay
+                        sx={{ fontSize: 'inherit', fontWeight: 'inherit' }}
+                      >
+                        {peer.userId}
+                      </PeerNameDisplay>{' '}
+                      via a relay server. Your connection is still private and
+                      encrypted, but performance may be degraded.
+                    </>
+                  )
+                }
+              >
+                <Box
+                  component="span"
+                  sx={{ pr: iconRightPadding, cursor: 'pointer' }}
+                >
+                  {isPeerConnectionDirect ? (
+                    <SyncAltIcon color="success" />
+                  ) : (
+                    <NetworkPingIcon color="warning" />
+                  )}
+                </Box>
+              </Tooltip>
+            ) : null}
+            <Box
+              component="span"
+              sx={{ pr: iconRightPadding, cursor: 'pointer' }}
+            >
+              {verificationStateDisplayMap[peer.verificationState]}
+            </Box>
+            <PeerNameDisplay>{peer.userId}</PeerNameDisplay>
           </Box>
-          <PeerNameDisplay>{peer.userId}</PeerNameDisplay>
           {peer.peerId in peerAudios && (
             <AudioVolume audioEl={peerAudios[peer.peerId]} />
           )}


### PR DESCRIPTION
For #217, this PR fixes a regression introduced by #216 that broke the display of the peer volume slider.

![Volume slider screenshot](https://github.com/jeremyckahn/chitchatter/assets/366330/c3043064-c4d2-4056-a8d1-a1f1f98056e1)
