### PR TITLE
feat(audio) [closes #230] Screenshare audio control

### DIFF
--- a/src/components/AudioVolume/AudioVolume.tsx
+++ b/src/components/AudioVolume/AudioVolume.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import Slider from '@mui/material/Slider'
 import Box from '@mui/material/Box'
+import Paper from '@mui/material/Paper'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import VolumeUpIcon from '@mui/icons-material/VolumeUp'
 import VolumeDownIcon from '@mui/icons-material/VolumeDown'
@@ -43,14 +44,23 @@ export const AudioVolume = ({ audioEl }: AudioVolumeProps) => {
   }
 
   return (
-    <Box sx={{ display: 'flex', pt: 1, pr: 3, alignItems: 'center' }}>
+    <Paper
+      sx={{
+        alignItems: 'center',
+        display: 'flex',
+        mt: 1.5,
+        pl: 2,
+        pr: 3,
+        py: 1,
+      }}
+    >
       <ListItemIcon sx={{ cursor: 'pointer' }} onClick={handleIconClick}>
         <VolumeIcon fontSize="small" />
         {
           // FIXME: Show peer's name
         }
         <Tooltip title="Their microphone volume">
-          <MicIcon fontSize="small" sx={{ mx: 1 }} />
+          <MicIcon fontSize="small" sx={{ ml: 1, mr: 2 }} />
         </Tooltip>
       </ListItemIcon>
       <Box display="flex" width={1}>
@@ -63,6 +73,6 @@ export const AudioVolume = ({ audioEl }: AudioVolumeProps) => {
           value={audioVolume * 100}
         ></Slider>
       </Box>
-    </Box>
+    </Paper>
   )
 }

--- a/src/components/AudioVolume/AudioVolume.tsx
+++ b/src/components/AudioVolume/AudioVolume.tsx
@@ -2,9 +2,11 @@ import { useState, useEffect } from 'react'
 import Slider from '@mui/material/Slider'
 import Box from '@mui/material/Box'
 import ListItemIcon from '@mui/material/ListItemIcon'
-import VolumeUp from '@mui/icons-material/VolumeUp'
-import VolumeDown from '@mui/icons-material/VolumeDown'
-import VolumeMute from '@mui/icons-material/VolumeMute'
+import VolumeUpIcon from '@mui/icons-material/VolumeUp'
+import VolumeDownIcon from '@mui/icons-material/VolumeDown'
+import VolumeMuteIcon from '@mui/icons-material/VolumeMute'
+import MicIcon from '@mui/icons-material/Mic'
+import Tooltip from '@mui/material/Tooltip'
 
 interface AudioVolumeProps {
   audioEl: HTMLAudioElement
@@ -32,27 +34,35 @@ export const AudioVolume = ({ audioEl }: AudioVolumeProps) => {
 
   const formatLabelValue = () => `${Math.round(audioVolume * 100)}%`
 
-  let VolumeIcon = VolumeUp
+  let VolumeIcon = VolumeUpIcon
 
   if (audioVolume === 0) {
-    VolumeIcon = VolumeMute
+    VolumeIcon = VolumeMuteIcon
   } else if (audioVolume < 0.5) {
-    VolumeIcon = VolumeDown
+    VolumeIcon = VolumeDownIcon
   }
 
   return (
     <Box sx={{ display: 'flex', pt: 1, pr: 3, alignItems: 'center' }}>
-      <ListItemIcon>
-        <VolumeIcon sx={{ cursor: 'pointer' }} onClick={handleIconClick} />
+      <ListItemIcon sx={{ cursor: 'pointer' }} onClick={handleIconClick}>
+        <VolumeIcon fontSize="small" />
+        {
+          // FIXME: Show peer's name
+        }
+        <Tooltip title="Their microphone volume">
+          <MicIcon fontSize="small" sx={{ mx: 1 }} />
+        </Tooltip>
       </ListItemIcon>
-      <Slider
-        aria-label="Volume"
-        getAriaValueText={formatLabelValue}
-        valueLabelFormat={formatLabelValue}
-        valueLabelDisplay="auto"
-        onChange={handleSliderChange}
-        value={audioVolume * 100}
-      ></Slider>
+      <Box display="flex" width={1}>
+        <Slider
+          aria-label="Volume"
+          getAriaValueText={formatLabelValue}
+          valueLabelFormat={formatLabelValue}
+          valueLabelDisplay="auto"
+          onChange={handleSliderChange}
+          value={audioVolume * 100}
+        ></Slider>
+      </Box>
     </Box>
   )
 }

--- a/src/components/AudioVolume/AudioVolume.tsx
+++ b/src/components/AudioVolume/AudioVolume.tsx
@@ -7,13 +7,19 @@ import VolumeUpIcon from '@mui/icons-material/VolumeUp'
 import VolumeDownIcon from '@mui/icons-material/VolumeDown'
 import VolumeMuteIcon from '@mui/icons-material/VolumeMute'
 import MicIcon from '@mui/icons-material/Mic'
+import LaptopWindowsIcon from '@mui/icons-material/LaptopWindows'
 import Tooltip from '@mui/material/Tooltip'
+import { AudioChannelName } from 'models/chat'
 
 interface AudioVolumeProps {
   audioEl: HTMLAudioElement
+  audioChannelName: AudioChannelName
 }
 
-export const AudioVolume = ({ audioEl }: AudioVolumeProps) => {
+export const AudioVolume = ({
+  audioEl,
+  audioChannelName,
+}: AudioVolumeProps) => {
   const [audioVolume, setAudioVolume] = useState(audioEl.volume)
 
   useEffect(() => {
@@ -56,15 +62,16 @@ export const AudioVolume = ({ audioEl }: AudioVolumeProps) => {
     >
       <ListItemIcon sx={{ cursor: 'pointer' }} onClick={handleIconClick}>
         <VolumeIcon fontSize="small" />
-        {
-          // FIXME: Show peer's name
-        }
-        <Tooltip title="Their microphone volume">
-          {
-            // FIXME: Show screen share icon as necessary
-          }
-          <MicIcon fontSize="small" sx={{ ml: 1, mr: 2 }} />
-        </Tooltip>
+        {audioChannelName === AudioChannelName.MICROPHONE && (
+          <Tooltip title="Their microphone volume">
+            <MicIcon fontSize="small" sx={{ ml: 1, mr: 2 }} />
+          </Tooltip>
+        )}
+        {audioChannelName === AudioChannelName.SCREEN_SHARE && (
+          <Tooltip title="Their screen's volume">
+            <LaptopWindowsIcon fontSize="small" sx={{ ml: 1, mr: 2 }} />
+          </Tooltip>
+        )}
       </ListItemIcon>
       <Box display="flex" width={1}>
         <Slider

--- a/src/components/AudioVolume/AudioVolume.tsx
+++ b/src/components/AudioVolume/AudioVolume.tsx
@@ -60,6 +60,9 @@ export const AudioVolume = ({ audioEl }: AudioVolumeProps) => {
           // FIXME: Show peer's name
         }
         <Tooltip title="Their microphone volume">
+          {
+            // FIXME: Show screen share icon as necessary
+          }
           <MicIcon fontSize="small" sx={{ ml: 1, mr: 2 }} />
         </Tooltip>
       </ListItemIcon>

--- a/src/components/Room/PeerVideo.tsx
+++ b/src/components/Room/PeerVideo.tsx
@@ -3,7 +3,7 @@ import Paper from '@mui/material/Paper'
 import Tooltip from '@mui/material/Tooltip'
 
 import { PeerNameDisplay } from 'components/PeerNameDisplay'
-import { VideoStreamType } from 'models/chat'
+import { StreamType } from 'models/chat'
 
 import { SelectedPeerStream } from './RoomVideoDisplay'
 
@@ -13,13 +13,13 @@ interface PeerVideoProps {
   numberOfVideos: number
   onVideoClick?: (
     userId: string,
-    videoStreamType: VideoStreamType,
+    streamType: StreamType,
     videoStream: MediaStream
   ) => void
   selectedPeerStream: SelectedPeerStream | null
   userId: string
   videoStream: MediaStream
-  videoStreamType: VideoStreamType
+  streamType: StreamType
 }
 
 // Adapted from https://www.geeksforgeeks.org/find-the-next-perfect-square-greater-than-a-given-number/
@@ -37,7 +37,7 @@ export const PeerVideo = ({
   userId,
   selectedPeerStream,
   videoStream,
-  videoStreamType,
+  streamType,
 }: PeerVideoProps) => {
   const videoRef = useRef<HTMLVideoElement>(null)
 
@@ -54,7 +54,7 @@ export const PeerVideo = ({
   const rows = Math.ceil(numberOfVideos / cols)
 
   const handleVideoClick = () => {
-    onVideoClick?.(userId, videoStreamType, videoStream)
+    onVideoClick?.(userId, streamType, videoStream)
   }
 
   return (

--- a/src/components/Room/PeerVideo.tsx
+++ b/src/components/Room/PeerVideo.tsx
@@ -47,6 +47,7 @@ export const PeerVideo = ({
 
     video.autoplay = true
     video.srcObject = videoStream
+    video.muted = true
   }, [videoRef, videoStream])
 
   const cols = Math.sqrt(nextPerfectSquare(numberOfVideos - 1))

--- a/src/components/Room/RoomVideoDisplay.tsx
+++ b/src/components/Room/RoomVideoDisplay.tsx
@@ -4,7 +4,7 @@ import Paper from '@mui/material/Paper'
 
 import { RoomContext } from 'contexts/RoomContext'
 import { ShellContext } from 'contexts/ShellContext'
-import { Peer, VideoStreamType } from 'models/chat'
+import { Peer, StreamType } from 'models/chat'
 
 import { PeerVideo } from './PeerVideo'
 
@@ -16,7 +16,7 @@ interface PeerWithVideo {
 
 export interface SelectedPeerStream {
   peerId: string
-  videoStreamType: VideoStreamType
+  streamType: StreamType
   videoStream: MediaStream
 }
 
@@ -105,13 +105,13 @@ export const RoomVideoDisplay = ({
 
   const handleVideoClick = (
     peerId: string,
-    videoStreamType: VideoStreamType,
+    streamType: StreamType,
     videoStream: MediaStream
   ) => {
     if (selectedPeerStream?.videoStream === videoStream) {
       setSelectedPeerStream(null)
     } else if (numberOfVideos > 1) {
-      setSelectedPeerStream({ peerId, videoStreamType, videoStream })
+      setSelectedPeerStream({ peerId, streamType, videoStream })
     }
   }
 
@@ -139,7 +139,7 @@ export const RoomVideoDisplay = ({
             userId={selectedPeerStream.peerId}
             selectedPeerStream={selectedPeerStream}
             videoStream={selectedPeerStream.videoStream}
-            videoStreamType={selectedPeerStream.videoStreamType}
+            streamType={selectedPeerStream.streamType}
           />
         </Box>
       )}
@@ -168,7 +168,7 @@ export const RoomVideoDisplay = ({
             userId={userId}
             selectedPeerStream={selectedPeerStream}
             videoStream={selfVideoStream}
-            videoStreamType={VideoStreamType.WEBCAM}
+            streamType={StreamType.WEBCAM}
           />
         )}
         {selfScreenStream && (
@@ -179,7 +179,7 @@ export const RoomVideoDisplay = ({
             userId={userId}
             selectedPeerStream={selectedPeerStream}
             videoStream={selfScreenStream}
-            videoStreamType={VideoStreamType.SCREEN_SHARE}
+            streamType={StreamType.SCREEN_SHARE}
           />
         )}
         {peersWithVideo.map(peerWithVideo => (
@@ -191,7 +191,7 @@ export const RoomVideoDisplay = ({
                 userId={peerWithVideo.peer.userId}
                 selectedPeerStream={selectedPeerStream}
                 videoStream={peerWithVideo.videoStream}
-                videoStreamType={VideoStreamType.WEBCAM}
+                streamType={StreamType.WEBCAM}
               />
             )}
             {peerWithVideo.screenStream && (
@@ -201,7 +201,7 @@ export const RoomVideoDisplay = ({
                 userId={peerWithVideo.peer.userId}
                 selectedPeerStream={selectedPeerStream}
                 videoStream={peerWithVideo.screenStream}
-                videoStreamType={VideoStreamType.SCREEN_SHARE}
+                streamType={StreamType.SCREEN_SHARE}
               />
             )}
           </Fragment>

--- a/src/components/Room/useRoom.ts
+++ b/src/components/Room/useRoom.ts
@@ -23,7 +23,7 @@ import {
   TypingStatus,
   Peer,
   PeerVerificationState,
-  PeerAudioChannelName,
+  AudioChannelName,
 } from 'models/chat'
 import { getPeerName, usePeerNameDisplay } from 'components/PeerNameDisplay'
 import { Audio } from 'lib/Audio'
@@ -271,8 +271,8 @@ export function useRoom(
           publicKey,
           customUsername,
           audioChannelState: {
-            [PeerAudioChannelName.MICROPHONE]: AudioState.STOPPED,
-            [PeerAudioChannelName.SCREEN_SHARE]: AudioState.STOPPED,
+            [AudioChannelName.MICROPHONE]: AudioState.STOPPED,
+            [AudioChannelName.SCREEN_SHARE]: AudioState.STOPPED,
           },
           videoState: VideoState.STOPPED,
           screenShareState: ScreenShareState.NOT_SHARING,

--- a/src/components/Room/useRoom.ts
+++ b/src/components/Room/useRoom.ts
@@ -269,7 +269,7 @@ export function useRoom(
           userId,
           publicKey,
           customUsername,
-          audioState: AudioState.STOPPED,
+          audioChannelState: { microphone: AudioState.STOPPED },
           videoState: VideoState.STOPPED,
           screenShareState: ScreenShareState.NOT_SHARING,
           offeredFileId: null,

--- a/src/components/Room/useRoom.ts
+++ b/src/components/Room/useRoom.ts
@@ -23,6 +23,7 @@ import {
   TypingStatus,
   Peer,
   PeerVerificationState,
+  PeerAudioChannelName,
 } from 'models/chat'
 import { getPeerName, usePeerNameDisplay } from 'components/PeerNameDisplay'
 import { Audio } from 'lib/Audio'
@@ -269,7 +270,9 @@ export function useRoom(
           userId,
           publicKey,
           customUsername,
-          audioChannelState: { microphone: AudioState.STOPPED },
+          audioChannelState: {
+            [PeerAudioChannelName.MICROPHONE]: AudioState.STOPPED,
+          },
           videoState: VideoState.STOPPED,
           screenShareState: ScreenShareState.NOT_SHARING,
           offeredFileId: null,

--- a/src/components/Room/useRoom.ts
+++ b/src/components/Room/useRoom.ts
@@ -272,6 +272,7 @@ export function useRoom(
           customUsername,
           audioChannelState: {
             [PeerAudioChannelName.MICROPHONE]: AudioState.STOPPED,
+            [PeerAudioChannelName.SCREEN_SHARE]: AudioState.STOPPED,
           },
           videoState: VideoState.STOPPED,
           screenShareState: ScreenShareState.NOT_SHARING,

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -201,12 +201,21 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
   }
 
   const deletePeerAudio = (peerId: string) => {
-    const newPeerAudios = { ...peerAudios }
-    const microphoneAudio = newPeerAudios[peerId][AudioChannelName.MICROPHONE]
-    microphoneAudio?.pause()
+    setPeerAudios(({ ...newPeerAudios }) => {
+      if (!newPeerAudios[peerId]) {
+        return newPeerAudios
+      }
 
-    delete newPeerAudios[peerId][AudioChannelName.MICROPHONE]
-    setPeerAudios(newPeerAudios)
+      const microphoneAudio = newPeerAudios[peerId][AudioChannelName.MICROPHONE]
+      microphoneAudio?.pause()
+
+      const { [AudioChannelName.MICROPHONE]: _, ...newPeerAudioChannels } =
+        newPeerAudios[peerId]
+
+      newPeerAudios[peerId] = newPeerAudioChannels
+
+      return newPeerAudios
+    })
   }
 
   const handleAudioForNewPeer = (peerId: string) => {

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -64,7 +64,7 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
           }
 
           if (peerAudioChannelState[channel] === AudioState.STOPPED) {
-            deletePeerAudio(peerId, channel)
+            deletePeerAudio(peerId)
           }
         }
       }
@@ -200,16 +200,9 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     setAudioStream(newSelfStream)
   }
 
-  const deletePeerAudio = (peerId: string, channel?: AudioChannelName) => {
+  const deletePeerAudio = (peerId: string) => {
     const newPeerAudios = { ...peerAudios }
-
-    if (channel) {
-      // FIXME: Use this code path
-      delete newPeerAudios[peerId][channel]
-    } else {
-      delete newPeerAudios[peerId]
-    }
-
+    delete newPeerAudios[peerId][AudioChannelName.MICROPHONE]
     setPeerAudios(newPeerAudios)
   }
 

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -8,6 +8,7 @@ import {
   AudioChannelName,
   PeerAudioChannelState,
   doesPeerHaveAudioChannel,
+  AudioStreamType,
 } from 'models/chat'
 import { PeerRoom, PeerHookType, PeerStreamType } from 'lib/PeerRoom'
 
@@ -113,7 +114,9 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
             video: false,
           })
 
-          peerRoom.addStream(newSelfStream)
+          peerRoom.addStream(newSelfStream, null, {
+            type: AudioStreamType.MICROPHONE,
+          })
 
           sendAudioChange({
             [AudioChannelName.MICROPHONE]: AudioState.PLAYING,
@@ -182,7 +185,10 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
       video: false,
     })
 
-    peerRoom.addStream(newSelfStream)
+    peerRoom.addStream(newSelfStream, null, {
+      type: AudioStreamType.MICROPHONE,
+    })
+
     setAudioStream(newSelfStream)
   }
 
@@ -201,7 +207,9 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
 
   const handleAudioForNewPeer = (peerId: string) => {
     if (audioStream) {
-      peerRoom.addStream(audioStream, peerId)
+      peerRoom.addStream(audioStream, peerId, {
+        type: AudioStreamType.MICROPHONE,
+      })
     }
   }
 

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -25,7 +25,8 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     string | null
   >(null)
 
-  const { setPeerList, setAudioChannelState, setPeerAudios } = shellContext
+  const { setPeerList, setAudioChannelState, setPeerAudioChannels } =
+    shellContext
 
   useEffect(() => {
     ;(async () => {
@@ -85,10 +86,10 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     audio.srcObject = stream
     audio.autoplay = true
 
-    setPeerAudios(peerAudios => ({
-      ...peerAudios,
+    setPeerAudioChannels(peerAudioChannels => ({
+      ...peerAudioChannels,
       [peerId]: {
-        ...peerAudios[peerId],
+        ...peerAudioChannels[peerId],
         [AudioChannelName.MICROPHONE]: audio,
       },
     }))
@@ -192,7 +193,7 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
   }
 
   const deletePeerAudio = (peerId: string) => {
-    setPeerAudios(({ ...newPeerAudios }) => {
+    setPeerAudioChannels(({ ...newPeerAudios }) => {
       if (!newPeerAudios[peerId]) {
         return newPeerAudios
       }

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -26,8 +26,13 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     string | null
   >(null)
 
-  const { peerList, setPeerList, setAudioState, peerAudios, setPeerAudios } =
-    shellContext
+  const {
+    peerList,
+    setPeerList,
+    setAudioChannelState,
+    peerAudios,
+    setPeerAudios,
+  } = shellContext
 
   useEffect(() => {
     ;(async () => {
@@ -109,10 +114,16 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
           })
 
           peerRoom.addStream(newSelfStream)
+
           sendAudioChange({
             [PeerAudioChannelName.MICROPHONE]: AudioState.PLAYING,
           })
-          setAudioState(AudioState.PLAYING)
+
+          setAudioChannelState(prevState => ({
+            ...prevState,
+            [PeerAudioChannelName.MICROPHONE]: AudioState.PLAYING,
+          }))
+
           setAudioStream(newSelfStream)
         }
       } else {
@@ -120,10 +131,16 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
           cleanupAudio()
 
           peerRoom.removeStream(audioStream, peerRoom.getPeers())
+
           sendAudioChange({
             [PeerAudioChannelName.MICROPHONE]: AudioState.STOPPED,
           })
-          setAudioState(AudioState.STOPPED)
+
+          setAudioChannelState(prevState => ({
+            ...prevState,
+            [PeerAudioChannelName.MICROPHONE]: AudioState.STOPPED,
+          }))
+
           setAudioStream(null)
         }
       }
@@ -136,7 +153,7 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     peerRoom,
     selectedAudioDeviceId,
     sendAudioChange,
-    setAudioState,
+    setAudioChannelState,
   ])
 
   useEffect(() => {

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -79,9 +79,10 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     if (
       typeof metadata === 'object' &&
       metadata !== null &&
-      'type' in metadata
+      'type' in metadata &&
+      metadata.type !== AudioStreamType.MICROPHONE
     ) {
-      if (metadata.type !== AudioStreamType.MICROPHONE) return
+      return
     }
 
     const audioTracks = stream.getAudioTracks()

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -2,7 +2,7 @@ import { useContext, useEffect, useCallback, useState } from 'react'
 
 import { ShellContext } from 'contexts/ShellContext'
 import { PeerActions } from 'models/network'
-import { AudioState, Peer } from 'models/chat'
+import { AudioState, Peer, PeerAudioChannel } from 'models/chat'
 import { PeerRoom, PeerHookType, PeerStreamType } from 'lib/PeerRoom'
 
 interface UseRoomAudioConfig {
@@ -149,10 +149,19 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     setAudioStream(newSelfStream)
   }
 
-  // FIXME: Add channel support here
-  const deletePeerAudio = (peerId: string) => {
+  const deletePeerAudio = (
+    peerId: string,
+    channel?: keyof PeerAudioChannel
+  ) => {
     const newPeerAudios = { ...peerAudios }
-    delete newPeerAudios[peerId]
+
+    if (channel) {
+      // FIXME: Use this code path
+      delete newPeerAudios[peerId][channel]
+    } else {
+      delete newPeerAudios[peerId]
+    }
+
     setPeerAudios(newPeerAudios)
   }
 

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -74,6 +74,7 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     setPeerList(newPeerList)
   })
 
+  // FIXME: This is mistakenly firing for screen share audio
   peerRoom.onPeerStream(PeerStreamType.AUDIO, (stream, peerId) => {
     const audioTracks = stream.getAudioTracks()
 

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -5,8 +5,7 @@ import { PeerActions } from 'models/network'
 import {
   AudioState,
   Peer,
-  PeerAudioChannel,
-  PeerAudioChannelName,
+  AudioChannelName,
   PeerAudioChannelState,
   doesPeerHaveAudioChannel,
 } from 'models/chat'
@@ -88,7 +87,7 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
       ...peerAudios,
       [peerId]: {
         ...peerAudios[peerId],
-        [PeerAudioChannelName.MICROPHONE]: audio,
+        [AudioChannelName.MICROPHONE]: audio,
       },
     })
   })
@@ -116,12 +115,12 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
           peerRoom.addStream(newSelfStream)
 
           sendAudioChange({
-            [PeerAudioChannelName.MICROPHONE]: AudioState.PLAYING,
+            [AudioChannelName.MICROPHONE]: AudioState.PLAYING,
           })
 
           setAudioChannelState(prevState => ({
             ...prevState,
-            [PeerAudioChannelName.MICROPHONE]: AudioState.PLAYING,
+            [AudioChannelName.MICROPHONE]: AudioState.PLAYING,
           }))
 
           setAudioStream(newSelfStream)
@@ -133,12 +132,12 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
           peerRoom.removeStream(audioStream, peerRoom.getPeers())
 
           sendAudioChange({
-            [PeerAudioChannelName.MICROPHONE]: AudioState.STOPPED,
+            [AudioChannelName.MICROPHONE]: AudioState.STOPPED,
           })
 
           setAudioChannelState(prevState => ({
             ...prevState,
-            [PeerAudioChannelName.MICROPHONE]: AudioState.STOPPED,
+            [AudioChannelName.MICROPHONE]: AudioState.STOPPED,
           }))
 
           setAudioStream(null)
@@ -186,10 +185,7 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     setAudioStream(newSelfStream)
   }
 
-  const deletePeerAudio = (
-    peerId: string,
-    channel?: keyof PeerAudioChannel
-  ) => {
+  const deletePeerAudio = (peerId: string, channel?: AudioChannelName) => {
     const newPeerAudios = { ...peerAudios }
 
     if (channel) {

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -6,6 +6,7 @@ import {
   AudioState,
   Peer,
   PeerAudioChannel,
+  PeerAudioChannelName,
   PeerAudioChannelState,
   doesPeerHaveAudioChannel,
 } from 'models/chat'
@@ -81,7 +82,7 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
       ...peerAudios,
       [peerId]: {
         ...peerAudios[peerId],
-        microphone: audio,
+        [PeerAudioChannelName.MICROPHONE]: audio,
       },
     })
   })
@@ -107,7 +108,9 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
           })
 
           peerRoom.addStream(newSelfStream)
-          sendAudioChange({ microphone: AudioState.PLAYING })
+          sendAudioChange({
+            [PeerAudioChannelName.MICROPHONE]: AudioState.PLAYING,
+          })
           setAudioState(AudioState.PLAYING)
           setAudioStream(newSelfStream)
         }
@@ -116,7 +119,9 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
           cleanupAudio()
 
           peerRoom.removeStream(audioStream, peerRoom.getPeers())
-          sendAudioChange({ microphone: AudioState.STOPPED })
+          sendAudioChange({
+            [PeerAudioChannelName.MICROPHONE]: AudioState.STOPPED,
+          })
           setAudioState(AudioState.STOPPED)
           setAudioStream(null)
         }

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -7,7 +7,7 @@ import {
   Peer,
   AudioChannelName,
   PeerAudioChannelState,
-  AudioStreamType,
+  StreamType,
 } from 'models/chat'
 import { PeerRoom, PeerHookType, PeerStreamType } from 'lib/PeerRoom'
 
@@ -73,7 +73,7 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
       typeof metadata === 'object' &&
       metadata !== null &&
       'type' in metadata &&
-      metadata.type !== AudioStreamType.MICROPHONE
+      metadata.type !== StreamType.MICROPHONE
     ) {
       return
     }
@@ -116,7 +116,7 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
           })
 
           peerRoom.addStream(newSelfStream, null, {
-            type: AudioStreamType.MICROPHONE,
+            type: StreamType.MICROPHONE,
           })
 
           sendAudioChange({
@@ -186,7 +186,7 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     })
 
     peerRoom.addStream(newSelfStream, null, {
-      type: AudioStreamType.MICROPHONE,
+      type: StreamType.MICROPHONE,
     })
 
     setAudioStream(newSelfStream)
@@ -213,7 +213,7 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
   const handleAudioForNewPeer = (peerId: string) => {
     if (audioStream) {
       peerRoom.addStream(audioStream, peerId, {
-        type: AudioStreamType.MICROPHONE,
+        type: StreamType.MICROPHONE,
       })
     }
   }

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -26,13 +26,8 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     string | null
   >(null)
 
-  const {
-    peerList,
-    setPeerList,
-    setAudioChannelState,
-    peerAudios,
-    setPeerAudios,
-  } = shellContext
+  const { peerList, setPeerList, setAudioChannelState, setPeerAudios } =
+    shellContext
 
   useEffect(() => {
     ;(async () => {
@@ -93,13 +88,13 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     audio.srcObject = stream
     audio.autoplay = true
 
-    setPeerAudios({
+    setPeerAudios(peerAudios => ({
       ...peerAudios,
       [peerId]: {
         ...peerAudios[peerId],
         [AudioChannelName.MICROPHONE]: audio,
       },
-    })
+    }))
   })
 
   const cleanupAudio = useCallback(() => {
@@ -160,7 +155,6 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     audioStream,
     cleanupAudio,
     isSpeakingToRoom,
-    peerAudios,
     peerRoom,
     selectedAudioDeviceId,
     sendAudioChange,

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -7,7 +7,6 @@ import {
   Peer,
   AudioChannelName,
   PeerAudioChannelState,
-  doesPeerHaveAudioChannel,
   AudioStreamType,
 } from 'models/chat'
 import { PeerRoom, PeerHookType, PeerStreamType } from 'lib/PeerRoom'
@@ -47,18 +46,17 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     const newPeerList = peerList.map(peer => {
       const newPeer: Peer = { ...peer }
 
-      for (const channel of Object.keys(peerAudioChannelState)) {
-        if (!doesPeerHaveAudioChannel(newPeer, channel)) {
-          continue
-        }
+      const microphoneAudioChannel =
+        peerAudioChannelState[AudioChannelName.MICROPHONE]
 
+      if (microphoneAudioChannel) {
         if (peer.peerId === peerId) {
           newPeer.audioChannelState = {
             ...newPeer.audioChannelState,
             ...peerAudioChannelState,
           }
 
-          if (peerAudioChannelState[channel] === AudioState.STOPPED) {
+          if (microphoneAudioChannel === AudioState.STOPPED) {
             deletePeerAudio(peerId)
           }
         }

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -202,6 +202,9 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
 
   const deletePeerAudio = (peerId: string) => {
     const newPeerAudios = { ...peerAudios }
+    const microphoneAudio = newPeerAudios[peerId][AudioChannelName.MICROPHONE]
+    microphoneAudio?.pause()
+
     delete newPeerAudios[peerId][AudioChannelName.MICROPHONE]
     setPeerAudios(newPeerAudios)
   }

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -75,8 +75,15 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     setPeerList(newPeerList)
   })
 
-  // FIXME: This is mistakenly firing for screen share audio
-  peerRoom.onPeerStream(PeerStreamType.AUDIO, (stream, peerId) => {
+  peerRoom.onPeerStream(PeerStreamType.AUDIO, (stream, peerId, metadata) => {
+    if (
+      typeof metadata === 'object' &&
+      metadata !== null &&
+      'type' in metadata
+    ) {
+      if (metadata.type !== AudioStreamType.MICROPHONE) return
+    }
+
     const audioTracks = stream.getAudioTracks()
 
     if (audioTracks.length === 0) return

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -63,7 +63,13 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     audio.srcObject = stream
     audio.autoplay = true
 
-    setPeerAudios({ ...peerAudios, [peerId]: audio })
+    setPeerAudios({
+      ...peerAudios,
+      [peerId]: {
+        ...peerAudios[peerId],
+        microphone: audio,
+      },
+    })
   })
 
   const cleanupAudio = useCallback(() => {
@@ -143,6 +149,7 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     setAudioStream(newSelfStream)
   }
 
+  // FIXME: Add channel support here
   const deletePeerAudio = (peerId: string) => {
     const newPeerAudios = { ...peerAudios }
     delete newPeerAudios[peerId]

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -39,8 +39,9 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     })()
   }, [audioStream])
 
-  const [sendAudioChange, receiveAudioChange] =
-    peerRoom.makeAction<PeerAudioChannelState>(PeerActions.AUDIO_CHANGE)
+  const [sendAudioChange, receiveAudioChange] = peerRoom.makeAction<
+    Partial<PeerAudioChannelState>
+  >(PeerActions.AUDIO_CHANGE)
 
   receiveAudioChange((peerAudioChannelState, peerId) => {
     const newPeerList = peerList.map(peer => {

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -25,8 +25,7 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
     string | null
   >(null)
 
-  const { peerList, setPeerList, setAudioChannelState, setPeerAudios } =
-    shellContext
+  const { setPeerList, setAudioChannelState, setPeerAudios } = shellContext
 
   useEffect(() => {
     ;(async () => {
@@ -43,29 +42,29 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
   >(PeerActions.AUDIO_CHANGE)
 
   receiveAudioChange((peerAudioChannelState, peerId) => {
-    const newPeerList = peerList.map(peer => {
-      const newPeer: Peer = { ...peer }
+    setPeerList(peerList => {
+      return peerList.map(peer => {
+        const newPeer: Peer = { ...peer }
 
-      const microphoneAudioChannel =
-        peerAudioChannelState[AudioChannelName.MICROPHONE]
+        const microphoneAudioChannel =
+          peerAudioChannelState[AudioChannelName.MICROPHONE]
 
-      if (microphoneAudioChannel) {
-        if (peer.peerId === peerId) {
-          newPeer.audioChannelState = {
-            ...newPeer.audioChannelState,
-            ...peerAudioChannelState,
-          }
+        if (microphoneAudioChannel) {
+          if (peer.peerId === peerId) {
+            newPeer.audioChannelState = {
+              ...newPeer.audioChannelState,
+              ...peerAudioChannelState,
+            }
 
-          if (microphoneAudioChannel === AudioState.STOPPED) {
-            deletePeerAudio(peerId)
+            if (microphoneAudioChannel === AudioState.STOPPED) {
+              deletePeerAudio(peerId)
+            }
           }
         }
-      }
 
-      return newPeer
+        return newPeer
+      })
     })
-
-    setPeerList(newPeerList)
   })
 
   peerRoom.onPeerStream(PeerStreamType.AUDIO, (stream, peerId, metadata) => {

--- a/src/components/Room/useRoomAudio.ts
+++ b/src/components/Room/useRoomAudio.ts
@@ -165,8 +165,9 @@ export function useRoomAudio({ peerRoom }: UseRoomAudioConfig) {
   const handleAudioForLeavingPeer = (peerId: string) => {
     if (audioStream) {
       peerRoom.removeStream(audioStream, peerId)
-      deletePeerAudio(peerId)
     }
+
+    deletePeerAudio(peerId)
   }
 
   peerRoom.onPeerJoin(PeerHookType.AUDIO, (peerId: string) => {

--- a/src/components/Room/useRoomScreenShare.ts
+++ b/src/components/Room/useRoomScreenShare.ts
@@ -27,7 +27,7 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
     setPeerList,
     setScreenState,
     setAudioChannelState,
-    setPeerAudios,
+    setPeerAudioChannels,
   } = shellContext
 
   const {
@@ -87,7 +87,7 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
         audio.autoplay = true
 
         // FIXME: This audio needs to be removed when the stream ends
-        setPeerAudios(prevState => {
+        setPeerAudioChannels(prevState => {
           return {
             ...prevState,
             [peerId]: {
@@ -164,7 +164,7 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
       return newPeerScreens
     })
 
-    setPeerAudios(({ ...newPeerAudios }) => {
+    setPeerAudioChannels(({ ...newPeerAudios }) => {
       if (!newPeerAudios[peerId]) {
         return newPeerAudios
       }

--- a/src/components/Room/useRoomScreenShare.ts
+++ b/src/components/Room/useRoomScreenShare.ts
@@ -88,6 +88,7 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
         audio.srcObject = stream
         audio.autoplay = true
 
+        // FIXME: This audio needs to be removed when the stream ends
         setPeerAudios(prevState => {
           return {
             ...prevState,

--- a/src/components/Room/useRoomScreenShare.ts
+++ b/src/components/Room/useRoomScreenShare.ts
@@ -86,7 +86,6 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
         audio.srcObject = stream
         audio.autoplay = true
 
-        // FIXME: This audio needs to be removed when the stream ends
         setPeerAudioChannels(peerAudioChannels => {
           return {
             ...peerAudioChannels,

--- a/src/components/Room/useRoomScreenShare.ts
+++ b/src/components/Room/useRoomScreenShare.ts
@@ -166,6 +166,11 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
     setPeerScreenStreams(newPeerScreens)
 
     const newPeerAudios = { ...peerAudios }
+    const screenShareAudio =
+      newPeerAudios[peerId][AudioChannelName.SCREEN_SHARE]
+
+    screenShareAudio?.pause()
+
     delete newPeerAudios[peerId][AudioChannelName.SCREEN_SHARE]
     setPeerAudios(newPeerAudios)
   }

--- a/src/components/Room/useRoomScreenShare.ts
+++ b/src/components/Room/useRoomScreenShare.ts
@@ -119,6 +119,7 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
     peerRoom.addStream(displayMedia, null, {
       type: VideoStreamType.SCREEN_SHARE,
     })
+
     setSelfScreenStream(displayMedia)
     sendScreenShare(ScreenShareState.SHARING)
     setScreenState(ScreenShareState.SHARING)

--- a/src/components/Room/useRoomScreenShare.ts
+++ b/src/components/Room/useRoomScreenShare.ts
@@ -24,7 +24,6 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
 
   const {
     peerList,
-    peerAudios,
     setPeerList,
     setScreenState,
     setAudioChannelState,
@@ -161,18 +160,27 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
   }, [setPeerScreenStreams])
 
   const deletePeerScreen = (peerId: string) => {
-    const newPeerScreens = { ...peerScreenStreams }
-    delete newPeerScreens[peerId]
-    setPeerScreenStreams(newPeerScreens)
+    setPeerScreenStreams(({ [peerId]: _, ...newPeerScreens }) => {
+      return newPeerScreens
+    })
 
-    const newPeerAudios = { ...peerAudios }
-    const screenShareAudio =
-      newPeerAudios[peerId][AudioChannelName.SCREEN_SHARE]
+    setPeerAudios(({ ...newPeerAudios }) => {
+      if (!newPeerAudios[peerId]) {
+        return newPeerAudios
+      }
 
-    screenShareAudio?.pause()
+      const screenShareAudio =
+        newPeerAudios[peerId][AudioChannelName.SCREEN_SHARE]
 
-    delete newPeerAudios[peerId][AudioChannelName.SCREEN_SHARE]
-    setPeerAudios(newPeerAudios)
+      screenShareAudio?.pause()
+
+      const { [AudioChannelName.SCREEN_SHARE]: _, ...newPeerAudioChannels } =
+        newPeerAudios[peerId]
+
+      newPeerAudios[peerId] = newPeerAudioChannels
+
+      return newPeerAudios
+    })
   }
 
   const handleScreenForNewPeer = (peerId: string) => {

--- a/src/components/Room/useRoomScreenShare.ts
+++ b/src/components/Room/useRoomScreenShare.ts
@@ -7,7 +7,7 @@ import { PeerActions } from 'models/network'
 import {
   ScreenShareState,
   Peer,
-  VideoStreamType,
+  StreamType,
   AudioChannelName,
   AudioState,
 } from 'models/chat'
@@ -62,7 +62,7 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
     const isScreenShareStream =
       isRecord(metadata) &&
       'type' in metadata &&
-      metadata.type === VideoStreamType.SCREEN_SHARE
+      metadata.type === StreamType.SCREEN_SHARE
 
     if (!isScreenShareStream) return
 
@@ -87,11 +87,11 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
         audio.autoplay = true
 
         // FIXME: This audio needs to be removed when the stream ends
-        setPeerAudioChannels(prevState => {
+        setPeerAudioChannels(peerAudioChannels => {
           return {
-            ...prevState,
+            ...peerAudioChannels,
             [peerId]: {
-              ...prevState[peerId],
+              ...peerAudioChannels[peerId],
               [AudioChannelName.SCREEN_SHARE]: audio,
             },
           }
@@ -118,7 +118,7 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
     })
 
     peerRoom.addStream(displayMedia, null, {
-      type: VideoStreamType.SCREEN_SHARE,
+      type: StreamType.SCREEN_SHARE,
     })
 
     setSelfScreenStream(displayMedia)
@@ -186,7 +186,7 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
   const handleScreenForNewPeer = (peerId: string) => {
     if (selfScreenStream) {
       peerRoom.addStream(selfScreenStream, peerId, {
-        type: VideoStreamType.SCREEN_SHARE,
+        type: StreamType.SCREEN_SHARE,
       })
     }
   }

--- a/src/components/Room/useRoomScreenShare.ts
+++ b/src/components/Room/useRoomScreenShare.ts
@@ -17,6 +17,8 @@ interface UseRoomScreenShareConfig {
   peerRoom: PeerRoom
 }
 
+// FIXME: Screen share audio streams are not being removed
+
 export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
   const shellContext = useContext(ShellContext)
   const roomContext = useContext(RoomContext)

--- a/src/components/Room/useRoomScreenShare.ts
+++ b/src/components/Room/useRoomScreenShare.ts
@@ -17,8 +17,6 @@ interface UseRoomScreenShareConfig {
   peerRoom: PeerRoom
 }
 
-// FIXME: Screen share audio streams are not being removed
-
 export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
   const shellContext = useContext(ShellContext)
   const roomContext = useContext(RoomContext)
@@ -26,6 +24,7 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
 
   const {
     peerList,
+    peerAudios,
     setPeerList,
     setScreenState,
     setAudioChannelState,
@@ -165,6 +164,10 @@ export function useRoomScreenShare({ peerRoom }: UseRoomScreenShareConfig) {
     const newPeerScreens = { ...peerScreenStreams }
     delete newPeerScreens[peerId]
     setPeerScreenStreams(newPeerScreens)
+
+    const newPeerAudios = { ...peerAudios }
+    delete newPeerAudios[peerId][AudioChannelName.SCREEN_SHARE]
+    setPeerAudios(newPeerAudios)
   }
 
   const handleScreenForNewPeer = (peerId: string) => {

--- a/src/components/Room/useRoomVideo.ts
+++ b/src/components/Room/useRoomVideo.ts
@@ -62,6 +62,7 @@ export function useRoomVideo({ peerRoom }: UseRoomVideoConfig) {
         peerRoom.addStream(newSelfStream, null, {
           type: VideoStreamType.WEBCAM,
         })
+
         setSelfVideoStream(newSelfStream)
       }
     })()
@@ -126,6 +127,7 @@ export function useRoomVideo({ peerRoom }: UseRoomVideoConfig) {
           peerRoom.addStream(newSelfStream, null, {
             type: VideoStreamType.WEBCAM,
           })
+
           sendVideoChange(VideoState.PLAYING)
           setVideoState(VideoState.PLAYING)
           setSelfVideoStream(newSelfStream)

--- a/src/components/Room/useRoomVideo.ts
+++ b/src/components/Room/useRoomVideo.ts
@@ -3,7 +3,7 @@ import { useContext, useEffect, useCallback, useState } from 'react'
 import { RoomContext } from 'contexts/RoomContext'
 import { ShellContext } from 'contexts/ShellContext'
 import { PeerActions } from 'models/network'
-import { VideoState, Peer, VideoStreamType } from 'models/chat'
+import { VideoState, Peer, StreamType } from 'models/chat'
 import { PeerRoom, PeerHookType, PeerStreamType } from 'lib/PeerRoom'
 import { isRecord } from 'lib/type-guards'
 
@@ -60,7 +60,7 @@ export function useRoomVideo({ peerRoom }: UseRoomVideoConfig) {
         })
 
         peerRoom.addStream(newSelfStream, null, {
-          type: VideoStreamType.WEBCAM,
+          type: StreamType.WEBCAM,
         })
 
         setSelfVideoStream(newSelfStream)
@@ -94,7 +94,7 @@ export function useRoomVideo({ peerRoom }: UseRoomVideoConfig) {
     const isWebcamStream =
       isRecord(metadata) &&
       'type' in metadata &&
-      metadata.type === VideoStreamType.WEBCAM
+      metadata.type === StreamType.WEBCAM
 
     if (!isWebcamStream) return
 
@@ -125,7 +125,7 @@ export function useRoomVideo({ peerRoom }: UseRoomVideoConfig) {
           })
 
           peerRoom.addStream(newSelfStream, null, {
-            type: VideoStreamType.WEBCAM,
+            type: StreamType.WEBCAM,
           })
 
           sendVideoChange(VideoState.PLAYING)
@@ -195,7 +195,7 @@ export function useRoomVideo({ peerRoom }: UseRoomVideoConfig) {
       },
     })
 
-    peerRoom.addStream(newSelfStream, null, { type: VideoStreamType.WEBCAM })
+    peerRoom.addStream(newSelfStream, null, { type: StreamType.WEBCAM })
     setSelfVideoStream(newSelfStream)
   }
 
@@ -208,7 +208,7 @@ export function useRoomVideo({ peerRoom }: UseRoomVideoConfig) {
   const handleVideoForNewPeer = (peerId: string) => {
     if (selfVideoStream) {
       peerRoom.addStream(selfVideoStream, peerId, {
-        type: VideoStreamType.WEBCAM,
+        type: StreamType.WEBCAM,
       })
     }
   }

--- a/src/components/Shell/PeerList.tsx
+++ b/src/components/Shell/PeerList.tsx
@@ -9,7 +9,7 @@ import Box from '@mui/material/Box'
 import CircularProgress from '@mui/material/CircularProgress'
 
 import { UserInfo } from 'components/UserInfo'
-import { AudioState, Peer } from 'models/chat'
+import { AudioState, Peer, PeerAudioChannel } from 'models/chat'
 import { PeerConnectionType } from 'lib/PeerRoom'
 import { TrackerConnection } from 'lib/ConnectionTest'
 
@@ -26,7 +26,7 @@ export interface PeerListProps extends PropsWithChildren {
   peerList: Peer[]
   peerConnectionTypes: Record<string, PeerConnectionType>
   audioState: AudioState
-  peerAudios: Record<string, HTMLAudioElement>
+  peerAudios: Record<string, PeerAudioChannel>
   connectionTestResults: IConnectionTestResults
 }
 

--- a/src/components/Shell/PeerList.tsx
+++ b/src/components/Shell/PeerList.tsx
@@ -32,7 +32,7 @@ export interface PeerListProps extends PropsWithChildren {
   peerList: Peer[]
   peerConnectionTypes: Record<string, PeerConnectionType>
   peerAudioChannelState: PeerAudioChannelState
-  peerAudios: Record<string, AudioChannel>
+  peerAudioChannels: Record<string, AudioChannel>
   connectionTestResults: IConnectionTestResults
 }
 
@@ -43,7 +43,7 @@ export const PeerList = ({
   peerList,
   peerConnectionTypes,
   peerAudioChannelState,
-  peerAudios,
+  peerAudioChannels,
   connectionTestResults,
 }: PeerListProps) => {
   return (
@@ -70,7 +70,7 @@ export const PeerList = ({
             key={peer.peerId}
             peer={peer}
             peerConnectionTypes={peerConnectionTypes}
-            peerAudios={peerAudios}
+            peerAudioChannels={peerAudioChannels}
           />
         ))}
         {peerList.length === 0 &&

--- a/src/components/Shell/PeerList.tsx
+++ b/src/components/Shell/PeerList.tsx
@@ -9,7 +9,13 @@ import Box from '@mui/material/Box'
 import CircularProgress from '@mui/material/CircularProgress'
 
 import { UserInfo } from 'components/UserInfo'
-import { AudioState, Peer, PeerAudioChannel } from 'models/chat'
+import {
+  AudioState,
+  Peer,
+  PeerAudioChannel,
+  PeerAudioChannelName,
+  PeerAudioChannelState,
+} from 'models/chat'
 import { PeerConnectionType } from 'lib/PeerRoom'
 import { TrackerConnection } from 'lib/ConnectionTest'
 
@@ -25,7 +31,7 @@ export interface PeerListProps extends PropsWithChildren {
   onPeerListClose: () => void
   peerList: Peer[]
   peerConnectionTypes: Record<string, PeerConnectionType>
-  audioState: AudioState
+  peerAudioChannelState: PeerAudioChannelState
   peerAudios: Record<string, PeerAudioChannel>
   connectionTestResults: IConnectionTestResults
 }
@@ -36,7 +42,7 @@ export const PeerList = ({
   onPeerListClose,
   peerList,
   peerConnectionTypes,
-  audioState,
+  peerAudioChannelState,
   peerAudios,
   connectionTestResults,
 }: PeerListProps) => {
@@ -49,7 +55,8 @@ export const PeerList = ({
       <Divider />
       <List>
         <ListItem divider={true}>
-          {audioState === AudioState.PLAYING && (
+          {peerAudioChannelState[PeerAudioChannelName.MICROPHONE] ===
+            AudioState.PLAYING && (
             <ListItemIcon>
               <VolumeUp />
             </ListItemIcon>

--- a/src/components/Shell/PeerList.tsx
+++ b/src/components/Shell/PeerList.tsx
@@ -12,8 +12,8 @@ import { UserInfo } from 'components/UserInfo'
 import {
   AudioState,
   Peer,
-  PeerAudioChannel,
-  PeerAudioChannelName,
+  AudioChannel,
+  AudioChannelName,
   PeerAudioChannelState,
 } from 'models/chat'
 import { PeerConnectionType } from 'lib/PeerRoom'
@@ -32,7 +32,7 @@ export interface PeerListProps extends PropsWithChildren {
   peerList: Peer[]
   peerConnectionTypes: Record<string, PeerConnectionType>
   peerAudioChannelState: PeerAudioChannelState
-  peerAudios: Record<string, PeerAudioChannel>
+  peerAudios: Record<string, AudioChannel>
   connectionTestResults: IConnectionTestResults
 }
 
@@ -55,7 +55,7 @@ export const PeerList = ({
       <Divider />
       <List>
         <ListItem divider={true}>
-          {peerAudioChannelState[PeerAudioChannelName.MICROPHONE] ===
+          {peerAudioChannelState[AudioChannelName.MICROPHONE] ===
             AudioState.PLAYING && (
             <ListItemIcon>
               <VolumeUp />

--- a/src/components/Shell/PeerListItem.tsx
+++ b/src/components/Shell/PeerListItem.tsx
@@ -31,7 +31,7 @@ import { PeerDownloadFileButton } from './PeerDownloadFileButton'
 interface PeerListItemProps {
   peer: Peer
   peerConnectionTypes: Record<string, PeerConnectionType>
-  peerAudios: Record<string, AudioChannel>
+  peerAudioChannels: Record<string, AudioChannel>
 }
 
 const verificationStateDisplayMap = {
@@ -57,7 +57,7 @@ const iconRightPadding = 1
 export const PeerListItem = ({
   peer,
   peerConnectionTypes,
-  peerAudios,
+  peerAudioChannels,
 }: PeerListItemProps) => {
   const [showPeerDialog, setShowPeerDialog] = useState(false)
 
@@ -74,9 +74,10 @@ export const PeerListItem = ({
     setShowPeerDialog(false)
   }
 
-  const microphoneAudio = peerAudios[peer.peerId]?.[AudioChannelName.MICROPHONE]
+  const microphoneAudio =
+    peerAudioChannels[peer.peerId]?.[AudioChannelName.MICROPHONE]
   const screenShareAudio =
-    peerAudios[peer.peerId]?.[AudioChannelName.SCREEN_SHARE]
+    peerAudioChannels[peer.peerId]?.[AudioChannelName.SCREEN_SHARE]
 
   return (
     <>

--- a/src/components/Shell/PeerListItem.tsx
+++ b/src/components/Shell/PeerListItem.tsx
@@ -126,10 +126,6 @@ export const PeerListItem = ({
           </Box>
           {peer.peerId in peerAudios && (
             <>
-              {
-                // FIXME: This is appearing when a peer is sending audio,
-                // leaves the room, and reconnects without audio.
-              }
               {peerAudios[peer.peerId].microphone && (
                 <AudioVolume audioEl={peerAudios[peer.peerId].microphone} />
               )}

--- a/src/components/Shell/PeerListItem.tsx
+++ b/src/components/Shell/PeerListItem.tsx
@@ -75,6 +75,8 @@ export const PeerListItem = ({
   }
 
   const microphoneAudio = peerAudios[peer.peerId]?.[AudioChannelName.MICROPHONE]
+  const screenShareAudio =
+    peerAudios[peer.peerId]?.[AudioChannelName.SCREEN_SHARE]
 
   return (
     <>
@@ -132,6 +134,7 @@ export const PeerListItem = ({
             <PeerNameDisplay>{peer.userId}</PeerNameDisplay>
           </Box>
           {microphoneAudio && <AudioVolume audioEl={microphoneAudio} />}
+          {screenShareAudio && <AudioVolume audioEl={screenShareAudio} />}
         </ListItemText>
       </ListItem>
       <Dialog open={showPeerDialog} onClose={handleDialogClose}>

--- a/src/components/Shell/PeerListItem.tsx
+++ b/src/components/Shell/PeerListItem.tsx
@@ -18,7 +18,12 @@ import EnhancedEncryptionIcon from '@mui/icons-material/EnhancedEncryption'
 import { AudioVolume } from 'components/AudioVolume'
 import { PeerNameDisplay } from 'components/PeerNameDisplay'
 import { PublicKey } from 'components/PublicKey'
-import { Peer, PeerAudioChannel, PeerVerificationState } from 'models/chat'
+import {
+  Peer,
+  PeerAudioChannel,
+  PeerAudioChannelName,
+  PeerVerificationState,
+} from 'models/chat'
 import { PeerConnectionType } from 'lib/PeerRoom'
 
 import { PeerDownloadFileButton } from './PeerDownloadFileButton'
@@ -69,7 +74,8 @@ export const PeerListItem = ({
     setShowPeerDialog(false)
   }
 
-  const microphoneAudio = peerAudios[peer.peerId]?.microphone
+  const microphoneAudio =
+    peerAudios[peer.peerId]?.[PeerAudioChannelName.MICROPHONE]
 
   return (
     <>

--- a/src/components/Shell/PeerListItem.tsx
+++ b/src/components/Shell/PeerListItem.tsx
@@ -133,8 +133,18 @@ export const PeerListItem = ({
             </Box>
             <PeerNameDisplay>{peer.userId}</PeerNameDisplay>
           </Box>
-          {microphoneAudio && <AudioVolume audioEl={microphoneAudio} />}
-          {screenShareAudio && <AudioVolume audioEl={screenShareAudio} />}
+          {microphoneAudio && (
+            <AudioVolume
+              audioEl={microphoneAudio}
+              audioChannelName={AudioChannelName.MICROPHONE}
+            />
+          )}
+          {screenShareAudio && (
+            <AudioVolume
+              audioEl={screenShareAudio}
+              audioChannelName={AudioChannelName.SCREEN_SHARE}
+            />
+          )}
         </ListItemText>
       </ListItem>
       <Dialog open={showPeerDialog} onClose={handleDialogClose}>

--- a/src/components/Shell/PeerListItem.tsx
+++ b/src/components/Shell/PeerListItem.tsx
@@ -69,6 +69,8 @@ export const PeerListItem = ({
     setShowPeerDialog(false)
   }
 
+  const microphoneAudio = peerAudios[peer.peerId]?.microphone
+
   return (
     <>
       <ListItem key={peer.peerId} divider={true}>
@@ -124,13 +126,7 @@ export const PeerListItem = ({
             </Box>
             <PeerNameDisplay>{peer.userId}</PeerNameDisplay>
           </Box>
-          {peer.peerId in peerAudios && (
-            <>
-              {peerAudios[peer.peerId].microphone && (
-                <AudioVolume audioEl={peerAudios[peer.peerId].microphone} />
-              )}
-            </>
-          )}
+          {microphoneAudio && <AudioVolume audioEl={microphoneAudio} />}
         </ListItemText>
       </ListItem>
       <Dialog open={showPeerDialog} onClose={handleDialogClose}>

--- a/src/components/Shell/PeerListItem.tsx
+++ b/src/components/Shell/PeerListItem.tsx
@@ -20,8 +20,8 @@ import { PeerNameDisplay } from 'components/PeerNameDisplay'
 import { PublicKey } from 'components/PublicKey'
 import {
   Peer,
-  PeerAudioChannel,
-  PeerAudioChannelName,
+  AudioChannel,
+  AudioChannelName,
   PeerVerificationState,
 } from 'models/chat'
 import { PeerConnectionType } from 'lib/PeerRoom'
@@ -31,7 +31,7 @@ import { PeerDownloadFileButton } from './PeerDownloadFileButton'
 interface PeerListItemProps {
   peer: Peer
   peerConnectionTypes: Record<string, PeerConnectionType>
-  peerAudios: Record<string, PeerAudioChannel>
+  peerAudios: Record<string, AudioChannel>
 }
 
 const verificationStateDisplayMap = {
@@ -74,8 +74,7 @@ export const PeerListItem = ({
     setShowPeerDialog(false)
   }
 
-  const microphoneAudio =
-    peerAudios[peer.peerId]?.[PeerAudioChannelName.MICROPHONE]
+  const microphoneAudio = peerAudios[peer.peerId]?.[AudioChannelName.MICROPHONE]
 
   return (
     <>

--- a/src/components/Shell/PeerListItem.tsx
+++ b/src/components/Shell/PeerListItem.tsx
@@ -18,7 +18,7 @@ import EnhancedEncryptionIcon from '@mui/icons-material/EnhancedEncryption'
 import { AudioVolume } from 'components/AudioVolume'
 import { PeerNameDisplay } from 'components/PeerNameDisplay'
 import { PublicKey } from 'components/PublicKey'
-import { Peer, PeerVerificationState } from 'models/chat'
+import { Peer, PeerAudioChannel, PeerVerificationState } from 'models/chat'
 import { PeerConnectionType } from 'lib/PeerRoom'
 
 import { PeerDownloadFileButton } from './PeerDownloadFileButton'
@@ -26,7 +26,7 @@ import { PeerDownloadFileButton } from './PeerDownloadFileButton'
 interface PeerListItemProps {
   peer: Peer
   peerConnectionTypes: Record<string, PeerConnectionType>
-  peerAudios: Record<string, HTMLAudioElement>
+  peerAudios: Record<string, PeerAudioChannel>
 }
 
 const verificationStateDisplayMap = {
@@ -53,7 +53,7 @@ export const PeerListItem = ({
   peer,
   peerConnectionTypes,
   peerAudios,
-}: PeerListItemProps): JSX.Element => {
+}: PeerListItemProps) => {
   const [showPeerDialog, setShowPeerDialog] = useState(false)
 
   const hasPeerConnection = peer.peerId in peerConnectionTypes
@@ -125,7 +125,15 @@ export const PeerListItem = ({
             <PeerNameDisplay>{peer.userId}</PeerNameDisplay>
           </Box>
           {peer.peerId in peerAudios && (
-            <AudioVolume audioEl={peerAudios[peer.peerId]} />
+            <>
+              {
+                // FIXME: This is appearing when a peer is sending audio,
+                // leaves the room, and reconnects without audio.
+              }
+              {peerAudios[peer.peerId].microphone && (
+                <AudioVolume audioEl={peerAudios[peer.peerId].microphone} />
+              )}
+            </>
           )}
         </ListItemText>
       </ListItem>

--- a/src/components/Shell/Shell.tsx
+++ b/src/components/Shell/Shell.tsx
@@ -25,6 +25,8 @@ import {
   VideoState,
   Peer,
   PeerAudioChannel,
+  PeerAudioChannelState,
+  PeerAudioChannelName,
 } from 'models/chat'
 import { ErrorBoundary } from 'components/ErrorBoundary'
 import { PeerConnectionType } from 'lib/PeerRoom'
@@ -92,7 +94,11 @@ export const Shell = ({ appNeedsUpdate, children, userPeerId }: ShellProps) => {
     Record<string, PeerConnectionType>
   >({})
   const [tabHasFocus, setTabHasFocus] = useState(true)
-  const [audioState, setAudioState] = useState<AudioState>(AudioState.STOPPED)
+  const [audioChannelState, setAudioChannelState] =
+    useState<PeerAudioChannelState>({
+      [PeerAudioChannelName.MICROPHONE]: AudioState.STOPPED,
+      [PeerAudioChannelName.SCREEN_SHARE]: AudioState.STOPPED,
+    })
   const [videoState, setVideoState] = useState<VideoState>(VideoState.STOPPED)
   const [screenState, setScreenState] = useState<ScreenShareState>(
     ScreenShareState.NOT_SHARING
@@ -150,8 +156,8 @@ export const Shell = ({ appNeedsUpdate, children, userPeerId }: ShellProps) => {
       setIsServerConnectionFailureDialogOpen,
       peerConnectionTypes,
       setPeerConnectionTypes,
-      audioState,
-      setAudioState,
+      audioChannelState,
+      setAudioChannelState,
       videoState,
       setVideoState,
       screenState,
@@ -180,8 +186,8 @@ export const Shell = ({ appNeedsUpdate, children, userPeerId }: ShellProps) => {
       setShowRoomControls,
       setTitle,
       showAlert,
-      audioState,
-      setAudioState,
+      audioChannelState,
+      setAudioChannelState,
       videoState,
       setVideoState,
       screenState,
@@ -399,7 +405,7 @@ export const Shell = ({ appNeedsUpdate, children, userPeerId }: ShellProps) => {
                   onPeerListClose={handlePeerListClick}
                   peerList={peerList}
                   peerConnectionTypes={peerConnectionTypes}
-                  audioState={audioState}
+                  peerAudioChannelState={audioChannelState}
                   peerAudios={peerAudios}
                   connectionTestResults={connectionTestResults}
                 />

--- a/src/components/Shell/Shell.tsx
+++ b/src/components/Shell/Shell.tsx
@@ -106,7 +106,9 @@ export const Shell = ({ appNeedsUpdate, children, userPeerId }: ShellProps) => {
   const [customUsername, setCustomUsername] = useState(
     getUserSettings().customUsername
   )
-  const [peerAudios, setPeerAudios] = useState<Record<string, AudioChannel>>({})
+  const [peerAudioChannels, setPeerAudioChannels] = useState<
+    Record<string, AudioChannel>
+  >({})
 
   const showAlert = useCallback((message: string, options?: AlertOptions) => {
     setAlertText(message)
@@ -160,8 +162,8 @@ export const Shell = ({ appNeedsUpdate, children, userPeerId }: ShellProps) => {
       setVideoState,
       screenState,
       setScreenState,
-      peerAudios,
-      setPeerAudios,
+      peerAudioChannels,
+      setPeerAudioChannels,
       customUsername,
       setCustomUsername,
       connectionTestResults,
@@ -190,8 +192,8 @@ export const Shell = ({ appNeedsUpdate, children, userPeerId }: ShellProps) => {
       setVideoState,
       screenState,
       setScreenState,
-      peerAudios,
-      setPeerAudios,
+      peerAudioChannels,
+      setPeerAudioChannels,
       customUsername,
       setCustomUsername,
       connectionTestResults,
@@ -404,7 +406,7 @@ export const Shell = ({ appNeedsUpdate, children, userPeerId }: ShellProps) => {
                   peerList={peerList}
                   peerConnectionTypes={peerConnectionTypes}
                   peerAudioChannelState={audioChannelState}
-                  peerAudios={peerAudios}
+                  peerAudioChannels={peerAudioChannels}
                   connectionTestResults={connectionTestResults}
                 />
                 {isEmbedded ? (

--- a/src/components/Shell/Shell.tsx
+++ b/src/components/Shell/Shell.tsx
@@ -19,7 +19,13 @@ import { useWindowSize } from '@react-hook/window-size'
 import { ShellContext } from 'contexts/ShellContext'
 import { SettingsContext } from 'contexts/SettingsContext'
 import { AlertOptions, QueryParamKeys } from 'models/shell'
-import { AudioState, ScreenShareState, VideoState, Peer } from 'models/chat'
+import {
+  AudioState,
+  ScreenShareState,
+  VideoState,
+  Peer,
+  PeerAudioChannel,
+} from 'models/chat'
 import { ErrorBoundary } from 'components/ErrorBoundary'
 import { PeerConnectionType } from 'lib/PeerRoom'
 
@@ -95,7 +101,7 @@ export const Shell = ({ appNeedsUpdate, children, userPeerId }: ShellProps) => {
     getUserSettings().customUsername
   )
   const [peerAudios, setPeerAudios] = useState<
-    Record<string, HTMLAudioElement>
+    Record<string, PeerAudioChannel>
   >({})
 
   const showAlert = useCallback((message: string, options?: AlertOptions) => {

--- a/src/components/Shell/Shell.tsx
+++ b/src/components/Shell/Shell.tsx
@@ -24,9 +24,9 @@ import {
   ScreenShareState,
   VideoState,
   Peer,
-  PeerAudioChannel,
+  AudioChannel,
   PeerAudioChannelState,
-  PeerAudioChannelName,
+  AudioChannelName,
 } from 'models/chat'
 import { ErrorBoundary } from 'components/ErrorBoundary'
 import { PeerConnectionType } from 'lib/PeerRoom'
@@ -96,8 +96,8 @@ export const Shell = ({ appNeedsUpdate, children, userPeerId }: ShellProps) => {
   const [tabHasFocus, setTabHasFocus] = useState(true)
   const [audioChannelState, setAudioChannelState] =
     useState<PeerAudioChannelState>({
-      [PeerAudioChannelName.MICROPHONE]: AudioState.STOPPED,
-      [PeerAudioChannelName.SCREEN_SHARE]: AudioState.STOPPED,
+      [AudioChannelName.MICROPHONE]: AudioState.STOPPED,
+      [AudioChannelName.SCREEN_SHARE]: AudioState.STOPPED,
     })
   const [videoState, setVideoState] = useState<VideoState>(VideoState.STOPPED)
   const [screenState, setScreenState] = useState<ScreenShareState>(
@@ -106,9 +106,7 @@ export const Shell = ({ appNeedsUpdate, children, userPeerId }: ShellProps) => {
   const [customUsername, setCustomUsername] = useState(
     getUserSettings().customUsername
   )
-  const [peerAudios, setPeerAudios] = useState<
-    Record<string, PeerAudioChannel>
-  >({})
+  const [peerAudios, setPeerAudios] = useState<Record<string, AudioChannel>>({})
 
   const showAlert = useCallback((message: string, options?: AlertOptions) => {
     setAlertText(message)

--- a/src/contexts/ShellContext.ts
+++ b/src/contexts/ShellContext.ts
@@ -41,8 +41,8 @@ interface ShellContextProps {
   setVideoState: Dispatch<SetStateAction<VideoState>>
   screenState: ScreenShareState
   setScreenState: Dispatch<SetStateAction<ScreenShareState>>
-  peerAudios: Record<string, AudioChannel>
-  setPeerAudios: Dispatch<SetStateAction<Record<string, AudioChannel>>>
+  peerAudioChannels: Record<string, AudioChannel>
+  setPeerAudioChannels: Dispatch<SetStateAction<Record<string, AudioChannel>>>
   customUsername: string
   setCustomUsername: Dispatch<SetStateAction<string>>
   connectionTestResults: ConnectionTestResults
@@ -77,8 +77,8 @@ export const ShellContext = createContext<ShellContextProps>({
   setVideoState: () => {},
   screenState: ScreenShareState.NOT_SHARING,
   setScreenState: () => {},
-  peerAudios: {},
-  setPeerAudios: () => {},
+  peerAudioChannels: {},
+  setPeerAudioChannels: () => {},
   customUsername: '',
   setCustomUsername: () => {},
   connectionTestResults: {

--- a/src/contexts/ShellContext.ts
+++ b/src/contexts/ShellContext.ts
@@ -1,7 +1,13 @@
 import { createContext, Dispatch, SetStateAction } from 'react'
 
 import { AlertOptions } from 'models/shell'
-import { AudioState, ScreenShareState, VideoState, Peer } from 'models/chat'
+import {
+  AudioState,
+  ScreenShareState,
+  VideoState,
+  Peer,
+  PeerAudioChannel,
+} from 'models/chat'
 import { PeerConnectionType } from 'lib/PeerRoom'
 import { ConnectionTestResults } from 'components/Shell/useConnectionTest'
 import { TrackerConnection } from 'lib/ConnectionTest'
@@ -33,8 +39,8 @@ interface ShellContextProps {
   setVideoState: Dispatch<SetStateAction<VideoState>>
   screenState: ScreenShareState
   setScreenState: Dispatch<SetStateAction<ScreenShareState>>
-  peerAudios: Record<string, HTMLAudioElement>
-  setPeerAudios: Dispatch<SetStateAction<Record<string, HTMLAudioElement>>>
+  peerAudios: Record<string, PeerAudioChannel>
+  setPeerAudios: Dispatch<SetStateAction<Record<string, PeerAudioChannel>>>
   customUsername: string
   setCustomUsername: Dispatch<SetStateAction<string>>
   connectionTestResults: ConnectionTestResults

--- a/src/contexts/ShellContext.ts
+++ b/src/contexts/ShellContext.ts
@@ -7,6 +7,8 @@ import {
   VideoState,
   Peer,
   PeerAudioChannel,
+  PeerAudioChannelState,
+  PeerAudioChannelName,
 } from 'models/chat'
 import { PeerConnectionType } from 'lib/PeerRoom'
 import { ConnectionTestResults } from 'components/Shell/useConnectionTest'
@@ -33,8 +35,8 @@ interface ShellContextProps {
   setPeerConnectionTypes: Dispatch<
     SetStateAction<Record<string, PeerConnectionType>>
   >
-  audioState: AudioState
-  setAudioState: Dispatch<SetStateAction<AudioState>>
+  audioChannelState: PeerAudioChannelState
+  setAudioChannelState: Dispatch<SetStateAction<PeerAudioChannelState>>
   videoState: VideoState
   setVideoState: Dispatch<SetStateAction<VideoState>>
   screenState: ScreenShareState
@@ -66,8 +68,11 @@ export const ShellContext = createContext<ShellContextProps>({
   setIsServerConnectionFailureDialogOpen: () => {},
   peerConnectionTypes: {},
   setPeerConnectionTypes: () => {},
-  audioState: AudioState.STOPPED,
-  setAudioState: () => {},
+  audioChannelState: {
+    [PeerAudioChannelName.MICROPHONE]: AudioState.STOPPED,
+    [PeerAudioChannelName.SCREEN_SHARE]: AudioState.STOPPED,
+  },
+  setAudioChannelState: () => {},
   videoState: VideoState.STOPPED,
   setVideoState: () => {},
   screenState: ScreenShareState.NOT_SHARING,

--- a/src/contexts/ShellContext.ts
+++ b/src/contexts/ShellContext.ts
@@ -6,9 +6,9 @@ import {
   ScreenShareState,
   VideoState,
   Peer,
-  PeerAudioChannel,
+  AudioChannel,
   PeerAudioChannelState,
-  PeerAudioChannelName,
+  AudioChannelName,
 } from 'models/chat'
 import { PeerConnectionType } from 'lib/PeerRoom'
 import { ConnectionTestResults } from 'components/Shell/useConnectionTest'
@@ -41,8 +41,8 @@ interface ShellContextProps {
   setVideoState: Dispatch<SetStateAction<VideoState>>
   screenState: ScreenShareState
   setScreenState: Dispatch<SetStateAction<ScreenShareState>>
-  peerAudios: Record<string, PeerAudioChannel>
-  setPeerAudios: Dispatch<SetStateAction<Record<string, PeerAudioChannel>>>
+  peerAudios: Record<string, AudioChannel>
+  setPeerAudios: Dispatch<SetStateAction<Record<string, AudioChannel>>>
   customUsername: string
   setCustomUsername: Dispatch<SetStateAction<string>>
   connectionTestResults: ConnectionTestResults
@@ -69,8 +69,8 @@ export const ShellContext = createContext<ShellContextProps>({
   peerConnectionTypes: {},
   setPeerConnectionTypes: () => {},
   audioChannelState: {
-    [PeerAudioChannelName.MICROPHONE]: AudioState.STOPPED,
-    [PeerAudioChannelName.SCREEN_SHARE]: AudioState.STOPPED,
+    [AudioChannelName.MICROPHONE]: AudioState.STOPPED,
+    [AudioChannelName.SCREEN_SHARE]: AudioState.STOPPED,
   },
   setAudioChannelState: () => {},
   videoState: VideoState.STOPPED,

--- a/src/lib/PeerRoom/PeerRoom.ts
+++ b/src/lib/PeerRoom/PeerRoom.ts
@@ -2,6 +2,7 @@ import { joinRoom, Room, BaseRoomConfig, DataPayload } from 'trystero'
 import { RelayConfig } from 'trystero/torrent'
 
 import { sleep } from 'lib/sleep'
+import { StreamType } from 'models/chat'
 
 export enum PeerHookType {
   NEW_PEER = 'NEW_PEER',
@@ -171,13 +172,16 @@ export class PeerRoom {
     return this.room.makeAction<T>(namespace)
   }
 
-  // FIXME: Define constraints for metadata param
-  addStream = (...args: Required<Parameters<Room['addStream']>>) => {
+  addStream = (
+    stream: Parameters<Room['addStream']>[0],
+    targetPeers: Parameters<Room['addStream']>[1],
+    metadata: { type: StreamType }
+  ) => {
     // New streams need to be added as a delayed queue to prevent race
     // conditions on the receiver's end where streams and their metadata get
     // mixed up.
     this.streamQueue.push(
-      () => Promise.all(this.room.addStream(...args)),
+      () => Promise.all(this.room.addStream(stream, targetPeers, metadata)),
       () => sleep(streamQueueAddDelay)
     )
 

--- a/src/lib/PeerRoom/PeerRoom.ts
+++ b/src/lib/PeerRoom/PeerRoom.ts
@@ -171,7 +171,8 @@ export class PeerRoom {
     return this.room.makeAction<T>(namespace)
   }
 
-  addStream = (...args: Parameters<Room['addStream']>) => {
+  // FIXME: Define constraints for metadata param
+  addStream = (...args: Required<Parameters<Room['addStream']>>) => {
     // New streams need to be added as a delayed queue to prevent race
     // conditions on the receiver's end where streams and their metadata get
     // mixed up.

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -51,12 +51,14 @@ export interface PeerAudioChannel {
   microphone?: HTMLAudioElement
 }
 
+export type PeerAudioChannelState = Record<keyof PeerAudioChannel, AudioState>
+
 export interface Peer {
   peerId: string
   userId: string
   publicKey: CryptoKey
   customUsername: string
-  audioState: AudioState
+  audioChannelState: PeerAudioChannelState
   videoState: VideoState
   screenShareState: ScreenShareState
   offeredFileId: string | null
@@ -65,6 +67,13 @@ export interface Peer {
   encryptedVerificationToken: ArrayBuffer
   verificationState: PeerVerificationState
   verificationTimer: NodeJS.Timeout | null
+}
+
+export const doesPeerHaveAudioChannel = (
+  peer: Peer,
+  channelName: string
+): channelName is keyof PeerAudioChannel => {
+  return channelName in peer.audioChannelState
 }
 
 export const isMessageReceived = (

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -47,16 +47,14 @@ export enum PeerVerificationState {
   VERIFIED,
 }
 
-export enum PeerAudioChannelName {
+export enum AudioChannelName {
   MICROPHONE = 'microphone',
   SCREEN_SHARE = 'screen-share',
 }
 
-export type PeerAudioChannel = Partial<
-  Record<PeerAudioChannelName, HTMLAudioElement>
->
+export type AudioChannel = Partial<Record<AudioChannelName, HTMLAudioElement>>
 
-export type PeerAudioChannelState = Record<PeerAudioChannelName, AudioState>
+export type PeerAudioChannelState = Record<AudioChannelName, AudioState>
 
 export interface Peer {
   peerId: string
@@ -77,7 +75,7 @@ export interface Peer {
 export const doesPeerHaveAudioChannel = (
   peer: Peer,
   channelName: string
-): channelName is keyof PeerAudioChannel => {
+): channelName is keyof AudioChannel => {
   return channelName in peer.audioChannelState
 }
 

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -47,11 +47,15 @@ export enum PeerVerificationState {
   VERIFIED,
 }
 
-export interface PeerAudioChannel {
-  microphone?: HTMLAudioElement
+export enum PeerAudioChannelName {
+  MICROPHONE = 'microphone',
 }
 
-export type PeerAudioChannelState = Record<keyof PeerAudioChannel, AudioState>
+export type PeerAudioChannel = Partial<
+  Record<PeerAudioChannelName, HTMLAudioElement>
+>
+
+export type PeerAudioChannelState = Record<PeerAudioChannelName, AudioState>
 
 export interface Peer {
   peerId: string

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -76,13 +76,6 @@ export interface Peer {
   verificationTimer: NodeJS.Timeout | null
 }
 
-export const doesPeerHaveAudioChannel = (
-  peer: Peer,
-  channelName: string
-): channelName is keyof AudioChannel => {
-  return channelName in peer.audioChannelState
-}
-
 export const isMessageReceived = (
   message: Message | InlineMedia
 ): message is ReceivedMessage | ReceivedInlineMedia => 'timeReceived' in message

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -31,13 +31,10 @@ export enum VideoState {
   STOPPED = 'STOPPED',
 }
 
-export enum AudioStreamType {
-  MICROPHONE = 'MICROPHONE',
-}
-
-export enum VideoStreamType {
+export enum StreamType {
   WEBCAM = 'WEBCAM',
   SCREEN_SHARE = 'SCREEN_SHARE',
+  MICROPHONE = 'MICROPHONE',
 }
 
 export enum ScreenShareState {

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -49,6 +49,7 @@ export enum PeerVerificationState {
 
 export enum PeerAudioChannelName {
   MICROPHONE = 'microphone',
+  SCREEN_SHARE = 'screen-share',
 }
 
 export type PeerAudioChannel = Partial<

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -47,6 +47,10 @@ export enum PeerVerificationState {
   VERIFIED,
 }
 
+export interface PeerAudioChannel {
+  microphone: HTMLAudioElement
+}
+
 export interface Peer {
   peerId: string
   userId: string

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -31,6 +31,10 @@ export enum VideoState {
   STOPPED = 'STOPPED',
 }
 
+export enum AudioStreamType {
+  MICROPHONE = 'MICROPHONE',
+}
+
 export enum VideoStreamType {
   WEBCAM = 'WEBCAM',
   SCREEN_SHARE = 'SCREEN_SHARE',

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -48,7 +48,7 @@ export enum PeerVerificationState {
 }
 
 export interface PeerAudioChannel {
-  microphone: HTMLAudioElement
+  microphone?: HTMLAudioElement
 }
 
 export interface Peer {


### PR DESCRIPTION
For #230, this PR implements multichannel audio volume control. It enables users to control the volume for shared screen audio independently from microphone audio from peers.

![Multichannel audio control screenshot](https://github.com/jeremyckahn/chitchatter/assets/366330/4852553c-d7fb-47bd-ab44-3cded58e5293)
