### PR TITLE
feat(home): Trim room name input

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -30,6 +30,10 @@ interface HomeProps {
   userId: string
 }
 
+const roomTypePrefixes = ['public', 'private']
+const roomTypePrefixesDelimitedForRegExp = roomTypePrefixes.join('|')
+const rRoomNameAppPrefix = `^${window.location.origin}/(${roomTypePrefixesDelimitedForRegExp})/`
+
 export function Home({ userId }: HomeProps) {
   const { setTitle } = useContext(ShellContext)
   const theme = useTheme()
@@ -43,7 +47,10 @@ export function Home({ userId }: HomeProps) {
 
   const handleRoomNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target
-    setRoomName(value)
+
+    const baseRoomName = value.replace(new RegExp(rRoomNameAppPrefix), '')
+
+    setRoomName(baseRoomName)
   }
 
   const handleFormSubmit = (event: React.SyntheticEvent<HTMLFormElement>) => {


### PR DESCRIPTION
This PR introduces a change to the Home component's room name input field. The input now automatically trims the application's URL prefix from the entered room name. This ensures that users only enter the room name itself, improving usability and preventing accidental inclusion of the URL prefix in the room name.