### PR TITLE
Show user id update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Chitchatter is a free (as in both price and freedom) communication tool. Designe
 - Ephemeral
   - Message content is never persisted to disk on either the client or server
 - Decentralized
-  - There is no API server. All that's required for Chitchatter to function is availability of GitHub for static assets, and public WebTorrent and STUN/TURN relay servers for establishing peer-to-peer communication.
+  - **No API server required**. Chitchatter works completely without an API server - all that's required for basic functionality is availability of GitHub for static assets, and public WebTorrent and STUN/TURN relay servers for establishing peer-to-peer communication. An optional API server is available to provide enhanced connectivity features, but users can always choose to use Chitchatter without it.
 - Embeddable
 - [Self-hostable](#self-hosting)
 
@@ -26,6 +26,8 @@ Chitchatter uses [Vite](https://vitejs.dev/). The secure networking and streamin
 ## How to use it
 
 Open <https://chitchatter.im/> and join a room to start chatting with anyone else who is in the room. By default, room names are random [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)s that are generated client-side. To privately communicate with someone, it is recommended to join one of these randomly-generated rooms and share the URL (via the "🔗" button at the top of the page) to whomever you wish to communicate with via a secure medium of your choosing (such as [Burner Note](https://burnernote.com/) or [Yopass](https://yopass.se/)). Your user name will be presented to you, and it would be good to share that with who you will be chatting with beforehand so they know they're talking to you.
+
+**No API server required**: Chitchatter works completely without any API server or backend infrastructure. All communication happens directly between your browser and other users' browsers. While an optional API server is available for enhanced connectivity features, you can always use Chitchatter without it.
 
 ## Features
 
@@ -196,6 +198,8 @@ The build is minified and the filenames include the hashes.
 
 ### API Configuration
 
+**Note: The API server is completely optional.** Chitchatter works without any API server - users can connect and communicate using only public STUN servers and fallback TURN servers. The API configuration described below is available for deployments that want to provide enhanced connectivity features.
+
 Chitchatter uses a hybrid approach for WebRTC configuration:
 
 - **TURN servers**: Fetched from the API endpoint (configurable via `VITE_RTC_CONFIG_ENDPOINT`, defaults to `/api/get-config`) with data configured via `RTC_CONFIG` environment variable
@@ -206,7 +210,7 @@ This separation allows for flexible configuration where TURN servers (which ofte
 
 #### Enhanced Connectivity Feature
 
-The Enhanced Connectivity feature in Chitchatter allows users to toggle the use of external TURN servers for improved connection reliability. This feature is **conditionally available** based on your deployment configuration:
+The Enhanced Connectivity feature is an **optional enhancement** that allows users to toggle the use of external TURN servers for improved connection reliability. **Chitchatter works perfectly without this feature** - it's simply an additional option for deployments that want to provide enhanced connectivity. This feature is **conditionally available** based on your deployment configuration:
 
 - **Available**: When `VITE_RTC_CONFIG_ENDPOINT` environment variable is set
 - **Unavailable**: When `VITE_RTC_CONFIG_ENDPOINT` is not set or empty

--- a/src/components/PeerNameDisplay/PeerNameDisplay.tsx
+++ b/src/components/PeerNameDisplay/PeerNameDisplay.tsx
@@ -1,77 +1,45 @@
+import React, { useState } from 'react'
 import Typography, { TypographyProps } from '@mui/material/Typography'
-import Box from '@mui/material/Box'
-import { useState } from 'react'
 
 import { usePeerNameDisplay } from './usePeerNameDisplay'
-import { getPeerName } from './getPeerName'
 
 export interface PeerNameDisplayProps extends TypographyProps {
   children: string // userId
+  showUserId?: boolean // Only show full/shortened user ID on Home page
 }
 
 export const PeerNameDisplay = ({
   children: userId,
+  showUserId = false,
   ...rest
 }: PeerNameDisplayProps) => {
-  const [isFullIdVisible, setIsFullIdVisible] = useState(false)
+  const { getFriendlyName } = usePeerNameDisplay()
+  const [isFullIdVisible, setIsFullIdVisible] = useState(false) // State for toggling full/shortened userId
 
-  const { getCustomUsername, getFriendlyName, getShortenedUserId } =
-    usePeerNameDisplay()
+  // Shortened version of userId
+  const shortId = (id: string) => `${id.slice(0, 4)}...${id.slice(-3)}`
 
-  const friendlyName = getFriendlyName(userId)
-  const customUsername = getCustomUsername(userId)
-  const shortUserId = getShortenedUserId(userId)
-
-  const displayName =
-    customUsername === friendlyName ? friendlyName : getPeerName(userId)
-
-  const isShortId = userId.length <= 12
-
-  const toggleUserId = () => {
-    if (!isShortId) {
-      setIsFullIdVisible(prev => !prev)
-    }
+  // Toggle full/shortened userId
+  const handleToggleUserId = () => {
+    setIsFullIdVisible(prev => !prev)
   }
 
-  const displayUserId = isShortId
-    ? userId
-    : isFullIdVisible
-      ? userId
-      : shortUserId
+  // If custom username is the same as the friendly name, display the friendly name
 
   return (
-    <Box
+    <Typography
       component="span"
-      sx={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        fontSize: '0.875rem',
-      }}
+      {...rest}
+      onClick={handleToggleUserId}
+      style={{ cursor: 'pointer' }}
     >
-      {/* Username */}
-      <Typography
-        component="span"
-        variant="body2"
-        sx={{ fontSize: 'inherit', fontWeight: 500 }}
-        {...rest}
-      >
-        {displayName}
-      </Typography>
-
-      {/* User ID */}
-      <Typography
-        component="span"
-        variant="caption"
-        onClick={toggleUserId}
-        sx={{
-          fontSize: 'inherit',
-          cursor: isShortId ? 'default' : 'pointer',
-          userSelect: 'none',
-        }}
-        {...rest}
-      >
-        {'\u00A0'}({displayUserId})
-      </Typography>
-    </Box>
+      {getFriendlyName(userId)}
+      {showUserId && (
+        <Typography variant="caption" component="span" {...rest}>
+          {' '}
+          ({isFullIdVisible ? userId : shortId(userId)})
+        </Typography>
+      )}
+    </Typography>
   )
 }

--- a/src/components/PeerNameDisplay/PeerNameDisplay.tsx
+++ b/src/components/PeerNameDisplay/PeerNameDisplay.tsx
@@ -13,11 +13,8 @@ export const PeerNameDisplay = ({
   showUserId = false,
   ...rest
 }: PeerNameDisplayProps) => {
-  const { getFriendlyName } = usePeerNameDisplay()
+  const { getFriendlyName, getShortenedUserId } = usePeerNameDisplay()
   const [isFullIdVisible, setIsFullIdVisible] = useState(false) // State for toggling full/shortened userId
-
-  // Shortened version of userId
-  const shortId = (id: string) => `${id.slice(0, 4)}...${id.slice(-3)}`
 
   // Toggle full/shortened userId
   const handleToggleUserId = () => {
@@ -30,14 +27,14 @@ export const PeerNameDisplay = ({
     <Typography
       component="span"
       {...rest}
-      onClick={handleToggleUserId}
-      style={{ cursor: 'pointer' }}
+      onClick={showUserId ? handleToggleUserId : undefined}
+      style={{ cursor: showUserId ? 'pointer' : 'inherit' }}
     >
       {getFriendlyName(userId)}
       {showUserId && (
         <Typography variant="caption" component="span" {...rest}>
           {' '}
-          ({isFullIdVisible ? userId : shortId(userId)})
+          ({isFullIdVisible ? userId : getShortenedUserId(userId)})
         </Typography>
       )}
     </Typography>

--- a/src/components/PeerNameDisplay/PeerNameDisplay.tsx
+++ b/src/components/PeerNameDisplay/PeerNameDisplay.tsx
@@ -1,36 +1,77 @@
 import Typography, { TypographyProps } from '@mui/material/Typography'
+import Box from '@mui/material/Box'
+import { useState } from 'react'
 
 import { usePeerNameDisplay } from './usePeerNameDisplay'
 import { getPeerName } from './getPeerName'
 
 export interface PeerNameDisplayProps extends TypographyProps {
-  children: string
+  children: string // userId
 }
 
 export const PeerNameDisplay = ({
   children: userId,
   ...rest
 }: PeerNameDisplayProps) => {
-  const { getCustomUsername, getFriendlyName } = usePeerNameDisplay()
+  const [isFullIdVisible, setIsFullIdVisible] = useState(false)
+
+  const { getCustomUsername, getFriendlyName, getShortenedUserId } =
+    usePeerNameDisplay()
 
   const friendlyName = getFriendlyName(userId)
   const customUsername = getCustomUsername(userId)
+  const shortUserId = getShortenedUserId(userId)
 
-  if (customUsername === friendlyName) {
-    return (
-      <Typography component="span" {...rest}>
-        {friendlyName}
-        <Typography variant="caption" {...rest}>
-          {' '}
-          ({getPeerName(userId)})
-        </Typography>
-      </Typography>
-    )
-  } else {
-    return (
-      <Typography component="span" {...rest}>
-        {getPeerName(userId)}
-      </Typography>
-    )
+  const displayName =
+    customUsername === friendlyName ? friendlyName : getPeerName(userId)
+
+  const isShortId = userId.length <= 12
+
+  const toggleUserId = () => {
+    if (!isShortId) {
+      setIsFullIdVisible(prev => !prev)
+    }
   }
+
+  const displayUserId = isShortId
+    ? userId
+    : isFullIdVisible
+      ? userId
+      : shortUserId
+
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        fontSize: '0.875rem',
+      }}
+    >
+      {/* Username */}
+      <Typography
+        component="span"
+        variant="body2"
+        sx={{ fontSize: 'inherit', fontWeight: 500 }}
+        {...rest}
+      >
+        {displayName}
+      </Typography>
+
+      {/* User ID */}
+      <Typography
+        component="span"
+        variant="caption"
+        onClick={toggleUserId}
+        sx={{
+          fontSize: 'inherit',
+          cursor: isShortId ? 'default' : 'pointer',
+          userSelect: 'none',
+        }}
+        {...rest}
+      >
+        {'\u00A0'}({displayUserId})
+      </Typography>
+    </Box>
+  )
 }

--- a/src/components/PeerNameDisplay/PeerNameDisplay.tsx
+++ b/src/components/PeerNameDisplay/PeerNameDisplay.tsx
@@ -10,7 +10,7 @@ export interface PeerNameDisplayProps extends TypographyProps {
 
 export const PeerNameDisplay = ({
   children: userId,
-  showUserId = false,
+  showUserId = true,
   ...rest
 }: PeerNameDisplayProps) => {
   const { getFriendlyName, getShortenedUserId } = usePeerNameDisplay()

--- a/src/components/PeerNameDisplay/usePeerNameDisplay.ts
+++ b/src/components/PeerNameDisplay/usePeerNameDisplay.ts
@@ -33,22 +33,26 @@ export const usePeerNameDisplay = () => {
   const getCustomUsername = (userId: string): string =>
     isPeerSelf(userId)
       ? selfCustomUsername
-      : getPeer(userId)?.customUsername || ''
+      : (getPeer(userId)?.customUsername ?? '')
 
   const getFriendlyName = (userId: string): string => {
     const customUsername = getCustomUsername(userId)
     return customUsername || getPeerName(userId)
   }
 
-  const getDisplayUsername = (userId: string): string => {
+  const getDisplayUsername = (userId: string) => {
     const friendlyName = getFriendlyName(userId)
     const customUsername = getCustomUsername(userId)
 
+    let displayUsername: string
+
     if (customUsername === friendlyName) {
-      return `${friendlyName} (${getPeerName(userId)})`
+      displayUsername = `${friendlyName} (${getPeerName(userId)})`
+    } else {
+      displayUsername = getPeerName(userId)
     }
 
-    return getPeerName(userId)
+    return displayUsername
   }
 
   return {

--- a/src/components/PeerNameDisplay/usePeerNameDisplay.ts
+++ b/src/components/PeerNameDisplay/usePeerNameDisplay.ts
@@ -6,7 +6,7 @@ import { getPeerName } from './getPeerName'
 
 // Constants to avoid magic numbers
 export const SHORT_ID_MAX_LENGTH = 12
-export const SHORT_ID_PREFIX_LENGTH = 6
+export const SHORT_ID_PREFIX_LENGTH = 4
 export const SHORT_ID_SUFFIX_LENGTH = 3
 
 // Utility to shorten userId if too long

--- a/src/components/PeerNameDisplay/usePeerNameDisplay.ts
+++ b/src/components/PeerNameDisplay/usePeerNameDisplay.ts
@@ -4,6 +4,20 @@ import { ShellContext } from 'contexts/ShellContext'
 
 import { getPeerName } from './getPeerName'
 
+// Constants to avoid magic numbers
+export const SHORT_ID_MAX_LENGTH = 12
+export const SHORT_ID_PREFIX_LENGTH = 6
+export const SHORT_ID_SUFFIX_LENGTH = 3
+
+// Utility to shorten userId if too long
+export const getShortenedUserId = (userId: string): string => {
+  if (userId.length <= SHORT_ID_MAX_LENGTH) return userId
+
+  const prefix = userId.slice(0, SHORT_ID_PREFIX_LENGTH)
+  const suffix = userId.slice(-SHORT_ID_SUFFIX_LENGTH)
+  return `${prefix}...${suffix}`
+}
+
 export const usePeerNameDisplay = () => {
   const { getUserSettings } = useContext(SettingsContext)
   const { peerList, customUsername: selfCustomUsername } =
@@ -11,44 +25,30 @@ export const usePeerNameDisplay = () => {
 
   const { userId: selfUserId } = getUserSettings()
 
-  const isPeerSelf = (userId: string) => selfUserId === userId
+  const isPeerSelf = (userId: string): boolean => selfUserId === userId
 
   const getPeer = (userId: string) =>
     peerList.find(peer => peer.userId === userId)
 
-  const getCustomUsername = (userId: string) =>
+  const getCustomUsername = (userId: string): string =>
     isPeerSelf(userId)
       ? selfCustomUsername
-      : (getPeer(userId)?.customUsername ?? '')
+      : getPeer(userId)?.customUsername || ''
 
-  const getFriendlyName = (userId: string) => {
+  const getFriendlyName = (userId: string): string => {
     const customUsername = getCustomUsername(userId)
-    const friendlyName = customUsername || getPeerName(userId)
-
-    return friendlyName
+    return customUsername || getPeerName(userId)
   }
 
-  const getDisplayUsername = (userId: string) => {
+  const getDisplayUsername = (userId: string): string => {
     const friendlyName = getFriendlyName(userId)
     const customUsername = getCustomUsername(userId)
 
-    let displayUsername: string
-
     if (customUsername === friendlyName) {
-      displayUsername = `${friendlyName} (${getPeerName(userId)})`
-    } else {
-      displayUsername = getPeerName(userId)
+      return `${friendlyName} (${getPeerName(userId)})`
     }
 
-    return displayUsername
-  }
-
-  // Returns a shortened version of the user ID for display.
-  const getShortenedUserId = (userId: string): string => {
-    if (userId.length <= 12) {
-      return userId
-    }
-    return `${userId.slice(0, 6)}...${userId.slice(-3)}`
+    return getPeerName(userId)
   }
 
   return {

--- a/src/components/PeerNameDisplay/usePeerNameDisplay.ts
+++ b/src/components/PeerNameDisplay/usePeerNameDisplay.ts
@@ -43,10 +43,19 @@ export const usePeerNameDisplay = () => {
     return displayUsername
   }
 
+  // Returns a shortened version of the user ID for display.
+  const getShortenedUserId = (userId: string): string => {
+    if (userId.length <= 12) {
+      return userId
+    }
+    return `${userId.slice(0, 6)}...${userId.slice(-3)}`
+  }
+
   return {
     getCustomUsername,
     isPeerSelf,
     getFriendlyName,
     getDisplayUsername,
+    getShortenedUserId,
   }
 }

--- a/src/contexts/SettingsContext.ts
+++ b/src/contexts/SettingsContext.ts
@@ -23,6 +23,5 @@ export const SettingsContext = createContext<SettingsContextProps>({
     publicKey: encryption.cryptoKeyStub,
     privateKey: encryption.cryptoKeyStub,
     selectedSound: DEFAULT_SOUND,
-    chatType: 'TEXT', // <-- Added this missing field
   }),
 })

--- a/src/contexts/SettingsContext.ts
+++ b/src/contexts/SettingsContext.ts
@@ -23,5 +23,6 @@ export const SettingsContext = createContext<SettingsContextProps>({
     publicKey: encryption.cryptoKeyStub,
     privateKey: encryption.cryptoKeyStub,
     selectedSound: DEFAULT_SOUND,
+    chatType: 'TEXT', // <-- Added this missing field
   }),
 })

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -87,10 +87,15 @@ export function Home({ userId }: HomeProps) {
         >
           <Typography sx={{ mb: 2 }}>
             Your username:{' '}
-            <PeerNameDisplay paragraph={false} sx={{ fontWeight: 'bold' }}>
+            <PeerNameDisplay
+              showUserId={true}
+              paragraph={false}
+              sx={{ fontWeight: 'bold' }}
+            >
               {userId}
             </PeerNameDisplay>
           </Typography>
+
           <FormControl fullWidth>
             <TextField
               label="Room name (generated on your device)"

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -97,7 +97,11 @@ export function Home({ userId }: HomeProps) {
         >
           <Typography sx={{ mb: 2 }}>
             Your username:{' '}
-            <PeerNameDisplay paragraph={false} sx={{ fontWeight: 'bold' }}>
+            <PeerNameDisplay
+              showUserId={true}
+              paragraph={false}
+              sx={{ fontWeight: 'bold' }}
+            >
               {userId}
             </PeerNameDisplay>
           </Typography>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -97,11 +97,7 @@ export function Home({ userId }: HomeProps) {
         >
           <Typography sx={{ mb: 2 }}>
             Your username:{' '}
-            <PeerNameDisplay
-              showUserId={true}
-              paragraph={false}
-              sx={{ fontWeight: 'bold' }}
-            >
+            <PeerNameDisplay paragraph={false} sx={{ fontWeight: 'bold' }}>
               {userId}
             </PeerNameDisplay>
           </Typography>


### PR DESCRIPTION
 **Feature**: _**Show user ID next to friendly name**_

Instead of only showing a generated name such as **"Enthusiastic Dingo"**, we now also show the user's **ID** like `"30051555-3155-4d38-ae96-1323a85e903d"`.
- By default, the ID is **shortened** (e.g., `"300...03d"`).
- Clicking the name toggles between the **shortened** and **full** user ID for better clarity and transparency.


> Originally suggested by @trymeouteh in [#464](https://github.com/jeremyckahn/chitchatter/issues/464).



