### PR TITLE
feat(app): Safely unregister service worker

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -74,6 +74,7 @@ const config = () => {
         injectRegister: 'auto',
         filename: 'service-worker.js',
         manifest,
+        selfDestroying: true,
       }),
     ],
     resolve: {


### PR DESCRIPTION
At a followup for #481, this PR disables the service worker (the removal of which was reverted in https://github.com/jeremyckahn/chitchatter/commit/1623dd2eca46cdd57ab3264f730ef39c6e433fdb after it was found to break app updates).

This is aligned with this documented approach: https://vite-pwa-org.netlify.app/guide/unregister-service-worker