### PR TITLE
fix: correct text color for received messages

### DIFF
--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -128,7 +128,7 @@ export const Message = ({ message, showAuthor, userId }: MessageProps) => {
       >
         <Box
           sx={{
-            color: 'primary.contrastText',
+            color: message.authorId === userId ? 'primary.contrastText' : 'secondary.contrastText',
             backgroundColor,
             margin: 0.5,
             padding: '0.5em 0.75em',


### PR DESCRIPTION
Received message box now correctly uses `secondary.contrastText` instead of `primary`